### PR TITLE
Update user documentation and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ make html
 $ xdg-open _build/html/index.html
 ```
 
-The *developper* documentation can be built and opened by running:
+The *developer* documentation can be built and opened by running:
 
 ```
 $ cargo doc --document-private-items --no-deps --lib --open

--- a/doc/gstarted.rst
+++ b/doc/gstarted.rst
@@ -32,7 +32,7 @@ Building lidi is fairly easy once you have all the dependencies set-up:
 
    $ cargo build --release
 
-This step provides you with the two main binaries for lidi: the sender and the receiver part, in addition to other utilitary binaries, such as file sending/receiving ones.
+This step provides you with the two main binaries for lidi: the sender and the receiver part, in addition to other utility binaries, such as file sending/receiving ones.
 
 Setting up a simple case
 ------------------------
@@ -74,6 +74,6 @@ Finally, we should be able to connect and send raw data through the diode in a f
    Hello Lidi!
    <Ctrl-D>
 
-The message should have been transfered with only forwarding UDP traffic, to finally show up in the first waiting netcat terminal window!
+The message should have been transferred with only forwarding UDP traffic, to finally show up in the first waiting netcat terminal window!
 
 Next steps is to review :ref:`Command line parameters` to adapt them to your use case, and eventually :ref:`Tweaking parameters` to achieve optimal transfer performances.

--- a/doc/gstarted.rst
+++ b/doc/gstarted.rst
@@ -47,11 +47,11 @@ In a first terminal, we start by running the sender part of lidi with default pa
 
 Some information logging should will show up, especially indicating that the diode is waiting for TCP connections on port 5000 and that the traffic will go through the diode on UDP port 6000.
 
-Next, we run the receiving part of lidi, with default parameters too:
+Next, we run the receiving part of lidi:
 
 .. code-block::
   
-   $ cargo run --release --bin diode-receive
+   $ cargo run --release --bin diode-receive -- --to_tcp 127.0.0.1:7000
 
 This time, logging will indicate that traffic will come up on UDP port 6000 and that transferred content will be served on TCP port 7000.
 
@@ -64,7 +64,7 @@ We run a first netcat instance waiting for connection on port 7000 with the foll
 
 .. code-block::
 
-   $ nc -lvp 7000
+   $ nc -lv 127.0.0.1 7000
 
 Finally, we should be able to connect and send raw data through the diode in a fourth terminal:
 

--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -46,8 +46,6 @@ On the diode-receive side, data will be sent to TCP connected clients. To specif
 
    --to_tcp <ip:port>
 
-Default value is 127.0.0.1:7000.
-
 Unix data source
 """"""""""""""""
 

--- a/src/bin/diode-send.rs
+++ b/src/bin/diode-send.rs
@@ -232,7 +232,7 @@ fn main() {
         encoding_block_size: config.encoding_block_size,
         repair_block_size: config.repair_block_size,
         nb_encoding_threads: config.nb_encoding_threads,
-        hearbeat_interval: config.heartbeat,
+        heartbeat_interval: config.heartbeat,
         to_bind: config.to_bind,
         to_udp: config.to_udp,
         to_mtu: config.to_udp_mtu,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -109,7 +109,7 @@ impl Message {
     /// Some (unchecked) constraints on arguments must be respected:
     /// - if `message` is `MessageType::Heartbeat`, `MessageType::Abort` or `MessageType::End`
     /// then no data should be provided,
-    /// - if `message` is `MessageType::Heartbear` then `client_id` should be equal to 0,
+    /// - if `message` is `MessageType::Heartbeat` then `client_id` should be equal to 0,
     /// - if there is some `data`, its length must be greater than `message_length`.
     pub(crate) fn new(
         message: MessageType,

--- a/src/receive/clients.rs
+++ b/src/receive/clients.rs
@@ -1,4 +1,4 @@
-//! Worker that aquires multiplex access and then becomes a `crate::receive::client` worker
+//! Worker that acquires multiplex access and then becomes a `crate::receive::client` worker
 
 use crate::{receive, receive::client};
 use std::{io::Write, os::fd::AsRawFd};

--- a/src/receive/reblock.rs
+++ b/src/receive/reblock.rs
@@ -31,7 +31,7 @@ pub(crate) fn start<F>(receiver: &receive::Receiver<F>) -> Result<(), receive::E
                         block_id = block_id.wrapping_add(1);
                     } else {
                         log::debug!(
-                            "no enough packets ({qlen} packates) to decode block {block_id}"
+                            "not enough packets ({qlen} packets) to decode block {block_id}"
                         );
                         log::warn!("lost block {block_id}");
                         desynchro = true;

--- a/src/send/heartbeat.rs
+++ b/src/send/heartbeat.rs
@@ -4,7 +4,7 @@ use crate::{protocol, send};
 
 pub(crate) fn start<C>(sender: &send::Sender<C>) -> Result<(), send::Error> {
     let alarm =
-        crossbeam_channel::tick(sender.config.hearbeat_interval.expect("heartbeat enabled"));
+        crossbeam_channel::tick(sender.config.heartbeat_interval.expect("heartbeat enabled"));
 
     loop {
         sender.to_encoding.send(protocol::Message::new(

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -39,7 +39,7 @@ pub struct Config {
     pub encoding_block_size: u64,
     pub repair_block_size: u32,
     pub nb_encoding_threads: u8,
-    pub hearbeat_interval: Option<time::Duration>,
+    pub heartbeat_interval: Option<time::Duration>,
     pub to_bind: net::SocketAddr,
     pub to_udp: net::SocketAddr,
     pub to_mtu: u16,
@@ -211,7 +211,7 @@ where
                 .spawn_scoped(scope, || encoding::start(self))?;
         }
 
-        if let Some(hb_interval) = self.config.hearbeat_interval {
+        if let Some(hb_interval) = self.config.heartbeat_interval {
             log::info!(
                 "heartbeat message will be sent every {} seconds",
                 hb_interval.as_secs()

--- a/src/sock_utils.rs
+++ b/src/sock_utils.rs
@@ -1,4 +1,4 @@
-//! Bindings and wrappers for socket buffer size libc funtions
+//! Bindings and wrappers for socket buffer size libc functions
 
 use std::os::fd::AsRawFd;
 use std::{io, mem, ptr};


### PR DESCRIPTION
Update user documentation: to start diode-receive, the user must supply either --to_tcp <ip:port> or --to_unix <path> argument.