### PR TITLE
diode-receive: refactor reblock; add flag reblock_retention_window

### DIFF
--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -132,6 +132,13 @@ Then, on the logical level, fountain codes operates on blocks. If blocks reorder
 The default value for an encoding block is 60000, and repair block size is defaulted to 10% of this value (6000).
 See the :ref:`Tweaking parameters` chapter for more details on how to choose optimal values for your particular use case and devices.
 
+Because of how UDP works, blocks may sometimes be received in a wildly different order: you may start receiving block number 12 before you finished receiving all packets for block number 10. Because of that, lidi will keep track of a given amount of blocks before considering them lost (up to 8 by default).
+
+.. code-block::
+
+   --reblock_retention_window <nb_blocks>
+     on the receiver side
+
 Multiplexing
 ------------
 

--- a/src/bin/diode-receive.rs
+++ b/src/bin/diode-receive.rs
@@ -18,6 +18,7 @@ struct Config {
     encoding_block_size: u64,
     repair_block_size: u32,
     udp_buffer_size: u32,
+    reblock_retention_window: u8,
     flush_timeout: time::Duration,
     nb_decoding_threads: u8,
     to: ClientConfig,
@@ -97,6 +98,14 @@ fn command_args() -> Config {
                 .help("Size of UDP socket recv buffer"),
         )
         .arg(
+            Arg::new("reblock_retention_window")
+                .long("reblock_retention_window")
+                .value_name("reblock_retention_window")
+                .default_value("8")
+                .value_parser(clap::value_parser!(u8).range(1..128))
+                .help("Higher value increases resilience to blocks getting mixed up"),
+        )
+        .arg(
             Arg::new("flush_timeout")
                 .long("flush_timeout")
                 .value_name("nb_milliseconds")
@@ -138,6 +147,9 @@ fn command_args() -> Config {
     let nb_decoding_threads = *args.get_one::<u8>("nb_decoding_threads").expect("default");
     let encoding_block_size = *args.get_one::<u64>("encoding_block_size").expect("default");
     let udp_buffer_size = *args.get_one::<u32>("udp_buffer_size").expect("default");
+    let reblock_retention_window = *args
+        .get_one::<u8>("reblock_retention_window")
+        .expect("default");
     let repair_block_size = *args.get_one::<u32>("repair_block_size").expect("default");
     let flush_timeout = time::Duration::from_millis(
         args.get_one::<NonZeroU64>("flush_timeout")
@@ -170,6 +182,7 @@ fn command_args() -> Config {
         encoding_block_size,
         repair_block_size,
         udp_buffer_size,
+        reblock_retention_window,
         flush_timeout,
         to,
         heartbeat,
@@ -238,6 +251,7 @@ fn main() {
             encoding_block_size: config.encoding_block_size,
             repair_block_size: config.repair_block_size,
             udp_buffer_size: config.udp_buffer_size,
+            reblock_retention_window: config.reblock_retention_window,
             flush_timeout: config.flush_timeout,
             nb_decoding_threads: config.nb_decoding_threads,
             heartbeat_interval: config.heartbeat,

--- a/src/receive/mod.rs
+++ b/src/receive/mod.rs
@@ -39,6 +39,7 @@ pub struct Config {
     pub encoding_block_size: u64,
     pub repair_block_size: u32,
     pub udp_buffer_size: u32,
+    pub reblock_retention_window: u8,
     pub flush_timeout: time::Duration,
     pub nb_decoding_threads: u8,
     pub heartbeat_interval: Option<time::Duration>,

--- a/src/receive/reblock.rs
+++ b/src/receive/reblock.rs
@@ -2,6 +2,52 @@
 //! reordering
 
 use crate::{protocol, receive};
+use std::collections::HashMap;
+
+const BLOCK_GAP_WARNING_THRESHOLD: u8 = 2;
+
+// Discards queues in Hashmap queues_by_block_id, where block_id is not between
+// (leading_block_id - window_size) and (leading_block_id).
+// Raises warnings for each discarded queue containing partial data (len < nb_normal_packets)
+fn discard_queues_outside_retention_window(
+    leading_block_id: u8,
+    window_size: u8,
+    queues_by_block_id: &mut HashMap<u8, Vec<raptorq::EncodingPacket>>,
+    nb_normal_packets: usize,
+) {
+    queues_by_block_id.retain(|&k, v| {
+        let retain = is_in_retention_window(k, leading_block_id, window_size);
+        if !retain && (v.len() < nb_normal_packets) {
+            log::warn!("discarding incomplete block {k} (currently on block {leading_block_id})")
+        }
+        return retain;
+    });
+}
+
+// Returns true if block_id is between (leading_block_id - window_size) and
+// leading_block_id; otherwise, returns false.
+fn is_in_retention_window(block_id: u8, leading_block_id: u8, window_size: u8) -> bool {
+    return is_in_wrapped_interval(
+        block_id,
+        (
+            leading_block_id.wrapping_sub(window_size - 1),
+            leading_block_id,
+        ),
+    );
+}
+
+// Returns true if value is between (leading_block_id - window_size) and
+// leading_block_id; otherwise, returns false.
+fn is_in_wrapped_interval(value: u8, interval: (u8, u8)) -> bool {
+    let (lower_bound, upper_bound) = interval;
+    if lower_bound < upper_bound {
+        // continuous interval like within 32-48
+        return lower_bound <= value && value <= upper_bound;
+    } else {
+        // wrapped interval like (0-8 or 248-255)
+        return value <= upper_bound || lower_bound <= value;
+    }
+}
 
 pub(crate) fn start<F>(receiver: &receive::Receiver<F>) -> Result<(), receive::Error> {
     let nb_normal_packets = protocol::nb_encoding_packets(&receiver.object_transmission_info);
@@ -9,12 +55,16 @@ pub(crate) fn start<F>(receiver: &receive::Receiver<F>) -> Result<(), receive::E
         &receiver.object_transmission_info,
         receiver.config.repair_block_size,
     );
+    let reblock_retention_window = receiver.config.reblock_retention_window;
 
-    let mut desynchro = true;
+    let mut next_block_id_overwrites_leading = true;
+
     let capacity = nb_normal_packets as usize + nb_repair_packets as usize;
-    let mut prev_queue: Option<Vec<raptorq::EncodingPacket>> = None;
-    let mut queue = Vec::with_capacity(capacity);
-    let mut block_id = 0;
+
+    let mut leading_block_id: u8 = 0;
+    let mut next_sendable_block_id: u8 = 0;
+    let mut queues_by_block_id: HashMap<u8, Vec<raptorq::EncodingPacket>> =
+        HashMap::with_capacity(reblock_retention_window as usize);
 
     loop {
         let packets = match receiver
@@ -22,26 +72,9 @@ pub(crate) fn start<F>(receiver: &receive::Receiver<F>) -> Result<(), receive::E
             .recv_timeout(receiver.config.flush_timeout)
         {
             Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
-                let qlen = queue.len();
-                if 0 < qlen {
-                    // no more traffic but ongoing block, trying to decode
-                    if nb_normal_packets as usize <= qlen {
-                        log::debug!("flushing block {block_id} with {qlen} packets");
-                        receiver.to_decoding.send((block_id, queue))?;
-                        block_id = block_id.wrapping_add(1);
-                    } else {
-                        log::debug!(
-                            "not enough packets ({qlen} packets) to decode block {block_id}"
-                        );
-                        log::warn!("lost block {block_id}");
-                        desynchro = true;
-                    }
-                    queue = Vec::with_capacity(capacity);
-                    prev_queue = None;
-                } else {
-                    // without data for some time we reset the current block_id
-                    desynchro = true;
-                }
+                log::trace!("timeout while waiting for next packets");
+                queues_by_block_id.clear();
+                next_block_id_overwrites_leading = true;
                 continue;
             }
             Err(e) => return Err(receive::Error::from(e)),
@@ -50,61 +83,131 @@ pub(crate) fn start<F>(receiver: &receive::Receiver<F>) -> Result<(), receive::E
 
         for packet in packets {
             let payload_id = packet.payload_id();
-            let message_block_id = payload_id.source_block_number();
+            let packet_block_id = payload_id.source_block_number();
 
-            if desynchro {
-                block_id = message_block_id;
-                *receiver.block_to_receive.lock().expect("acquire lock") = block_id;
-                desynchro = false;
-            }
+            if next_block_id_overwrites_leading {
+                log::debug!("new leading block id: ({packet_block_id})");
+                leading_block_id = packet_block_id;
+                next_sendable_block_id = packet_block_id;
+                next_block_id_overwrites_leading = false;
+            } else if !is_in_retention_window(
+                packet_block_id,
+                leading_block_id,
+                reblock_retention_window,
+            ) {
+                log::debug!("new leading block id: {packet_block_id} (was {leading_block_id})");
+                if !is_in_wrapped_interval(
+                    packet_block_id,
+                    (
+                        leading_block_id,
+                        leading_block_id + BLOCK_GAP_WARNING_THRESHOLD,
+                    ),
+                ) {
+                    log::warn!("large gap in block sequence (received {packet_block_id} while on block {leading_block_id})")
+                }
+                leading_block_id = packet_block_id;
 
-            if message_block_id == block_id {
-                log::trace!("queueing in block {block_id}");
-                queue.push(packet);
-                continue;
-            }
+                log::debug!("discarding all packets for blocks outside new retention window");
+                discard_queues_outside_retention_window(
+                    leading_block_id,
+                    reblock_retention_window,
+                    &mut queues_by_block_id,
+                    nb_normal_packets as usize,
+                );
 
-            if message_block_id.wrapping_add(1) == block_id {
-                //packet is from previous block; is this block parked ?
-                if let Some(mut pqueue) = prev_queue {
-                    pqueue.push(packet);
-                    if nb_normal_packets as usize <= pqueue.len() {
-                        //now there is enough packets to decode it
-                        receiver.to_decoding.send((message_block_id, pqueue))?;
-                        prev_queue = None;
-                    } else {
-                        prev_queue = Some(pqueue);
+                // update next_sendable_block_id if now outside window
+                if !is_in_retention_window(
+                    next_sendable_block_id,
+                    leading_block_id,
+                    reblock_retention_window,
+                ) {
+                    next_sendable_block_id =
+                        leading_block_id.wrapping_sub(reblock_retention_window - 1);
+                    log::debug!("bumped next_sendable_block_id to {next_sendable_block_id}");
+
+                    // check sendable queues
+                    loop {
+                        let queue = queues_by_block_id
+                            .entry(next_sendable_block_id)
+                            .or_insert(Vec::with_capacity(capacity));
+                        let qlen = queue.len();
+                        let queue_packet_id = next_sendable_block_id;
+
+                        if (nb_normal_packets as usize) > qlen {
+                            break;
+                        }
+                        log::debug!("trying to decode block {queue_packet_id} with {qlen} packets");
+                        receiver
+                            .to_decoding
+                            .send((queue_packet_id, queue.to_vec()))?;
+                        next_sendable_block_id = next_sendable_block_id.wrapping_add(1);
                     }
                 }
-                continue;
             }
 
-            if message_block_id != block_id.wrapping_add(1) {
-                log::warn!("discarding packet with block_id {message_block_id} (current block_id is {block_id})");
-                continue;
-            }
+            // push packet into queue
+            let mut queue = queues_by_block_id
+                .entry(packet_block_id)
+                .or_insert(Vec::with_capacity(capacity));
+            let mut qlen = queue.len();
+            let mut queue_packet_id = packet_block_id;
 
-            //this is the first packet of the next block
-
-            if nb_normal_packets as usize <= queue.len() {
-                //enough packets in the current block to decode it
-                receiver.to_decoding.send((block_id, queue))?;
-                if prev_queue.is_some() {
-                    log::warn!("lost block {}", block_id.wrapping_sub(1));
-                }
-                prev_queue = None;
-            } else {
-                //not enough packet, parking the current block
-                prev_queue = Some(queue);
-            }
-
-            //starting the next block
-
-            block_id = message_block_id;
-
-            log::trace!("queueing in block {block_id}");
-            queue = Vec::with_capacity(capacity);
+            log::trace!("queueing packet for block {packet_block_id}");
             queue.push(packet);
+
+            // send block if enough packets
+            while nb_normal_packets as usize == qlen {
+                if next_sendable_block_id != queue_packet_id {
+                    log::debug!("ready to decode block {queue_packet_id} with {qlen} packets, but still waiting on block {next_sendable_block_id}");
+                    break;
+                }
+
+                log::debug!("trying to decode block {queue_packet_id} with {qlen} packets");
+                receiver
+                    .to_decoding
+                    .send((queue_packet_id, queue.to_vec()))?;
+
+                next_sendable_block_id = next_sendable_block_id.wrapping_add(1);
+
+                // check if next queue is ready to send
+                queue = queues_by_block_id
+                    .entry(next_sendable_block_id)
+                    .or_insert(Vec::with_capacity(capacity));
+                qlen = queue.len();
+                queue_packet_id = next_sendable_block_id;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_in_wrapped_interval;
+
+    #[test]
+    fn test_is_in_wrapped_interval() {
+        for (value, lower_bound, upper_bound, expected_result) in vec![
+            (0, 0, 0, true),
+            (0, 0, 255, true),
+            // continuous interval
+            (29, 30, 40, false),
+            (30, 30, 40, true),
+            (31, 30, 40, true),
+            (40, 30, 40, true),
+            (41, 30, 40, false),
+            // wrapping
+            (29, 40, 30, true),
+            (30, 40, 30, true),
+            (31, 40, 30, false),
+            (40, 40, 30, true),
+            (41, 40, 30, true),
+            // edge cases
+            (0, 255, 0, true),
+            (3, 255, 0, false),
+            (255, 255, 0, true),
+        ] {
+            let res = is_in_wrapped_interval(value, (lower_bound, upper_bound));
+            assert_eq!(expected_result, res, "expected {expected_result}; got {res}. value: {value}; lower_bound: {lower_bound}; upper_bound: {upper_bound}");
         }
     }
 }


### PR DESCRIPTION
Rewrites the reblock part of the receiving end, in order to allow lidi to process more than two mixed up blocks.