### PR TITLE
Added functionality to set bandwidth limits to avoid receiver overflow.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - "172.16.0.2:5000"
       - "--to_udp"
       - "172.16.0.3:6000"
+      - "--bandwidth_limit"
+      - "10"
 
   receive:
     image: diode:receive

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -44,6 +44,7 @@ pub struct Config {
     pub to_bind: net::SocketAddr,
     pub to_udp: net::SocketAddr,
     pub to_mtu: u16,
+    pub bandwidth_limit: f64,
 }
 
 impl Config {

--- a/src/send/udp.rs
+++ b/src/send/udp.rs
@@ -25,6 +25,7 @@ pub(crate) fn start<C>(sender: &send::Sender<C>) -> Result<(), send::Error> {
         socket,
         usize::from(sender.to_max_messages),
         sender.config.to_udp,
+        sender.config.bandwidth_limit,
     );
 
     loop {

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -2,7 +2,8 @@
 
 use std::marker::PhantomData;
 use std::os::fd::AsRawFd;
-use std::{io, mem, net};
+use std::time::{Duration, Instant};
+use std::{io, mem, net, thread};
 
 pub struct UdpRecv;
 pub struct UdpSend;
@@ -20,6 +21,7 @@ pub struct UdpMessages<D> {
     iovecs: Vec<libc::iovec>,
     buffers: Vec<Vec<u8>>,
     marker: PhantomData<D>,
+    bandwidth_limit: f64,
 }
 
 impl<D> UdpMessages<D> {
@@ -28,6 +30,7 @@ impl<D> UdpMessages<D> {
         vlen: usize,
         msglen: Option<usize>,
         addr: Option<net::SocketAddr>,
+        bandwidth_limit: f64,
     ) -> Self {
         let (mut msgvec, mut iovecs, mut buffers);
 
@@ -89,6 +92,7 @@ impl<D> UdpMessages<D> {
             iovecs,
             buffers,
             marker: PhantomData,
+            bandwidth_limit,
         }
     }
 }
@@ -96,7 +100,7 @@ impl<D> UdpMessages<D> {
 impl UdpMessages<UdpRecv> {
     pub fn new_receiver(socket: net::UdpSocket, vlen: usize, msglen: usize) -> Self {
         log::info!("UDP configured to receive {vlen} messages (datagrams)");
-        Self::new(socket, vlen, Some(msglen), None)
+        Self::new(socket, vlen, Some(msglen), None, 0.0)
     }
 
     pub fn recv_mmsg(&mut self) -> Result<impl Iterator<Item = &[u8]>, io::Error> {
@@ -128,35 +132,67 @@ impl UdpMessages<UdpSend> {
         socket: net::UdpSocket,
         vlen: usize,
         dest: net::SocketAddr,
+        bandwidth_limit: f64,
     ) -> UdpMessages<UdpSend> {
         log::info!("UDP configured to send {vlen} messages (datagrams) at a time");
-        Self::new(socket, vlen, None, Some(dest))
+        //std::println!("{}",udpdelay.unwrap().as_micros());
+        Self::new(socket, vlen, None, Some(dest), bandwidth_limit)
     }
 
     pub fn send_mmsg(&mut self, mut buffers: Vec<Vec<u8>>) -> Result<(), io::Error> {
         for bufchunk in buffers.chunks_mut(self.vlen) {
-            let to_send = bufchunk.len();
+            if self.bandwidth_limit > 0.0 {
+                for (i, buf) in bufchunk.iter_mut().enumerate() {
+                    self.msgvec[i].msg_len = buf.len() as u32;
+                    self.iovecs[i].iov_base = buf.as_mut_ptr().cast::<libc::c_void>();
+                    self.iovecs[i].iov_len = buf.len();
 
-            for (i, buf) in bufchunk.iter_mut().enumerate() {
-                self.msgvec[i].msg_len = buf.len() as u32;
-                self.iovecs[i].iov_base = buf.as_mut_ptr().cast::<libc::c_void>();
-                self.iovecs[i].iov_len = buf.len();
-            }
+                    let start_time = Instant::now();
+                    let nb_msg;
+                    unsafe {
+                        nb_msg = libc::sendmmsg(self.socket.as_raw_fd(), &mut self.msgvec[i], 1, 0);
+                    }
 
-            let nb_msg;
-            unsafe {
-                nb_msg = libc::sendmmsg(
-                    self.socket.as_raw_fd(),
-                    self.msgvec.as_mut_ptr(),
-                    to_send as u32,
-                    0,
-                );
-            }
-            if nb_msg == -1 {
-                return Err(io::Error::new(io::ErrorKind::Other, "libc::sendmmsg"));
-            }
-            if nb_msg as usize != to_send {
-                log::warn!("nb prepared messages doesn't match with nb sent messages");
+                    if nb_msg == -1 {
+                        return Err(io::Error::new(io::ErrorKind::Other, "libc::sendmmsg"));
+                    }
+
+                    let send_duration = start_time.elapsed().as_secs_f64();
+                    let bytes_sent = buf.len() as f64;
+                    let ideal_time_per_byte = 1.0 / self.bandwidth_limit;
+                    let ideal_send_duration = bytes_sent * ideal_time_per_byte;
+                    let sleep_duration = if ideal_send_duration > send_duration {
+                        Duration::from_secs_f64(ideal_send_duration - send_duration)
+                    } else {
+                        Duration::from_secs(0)
+                    };
+
+                    thread::sleep(sleep_duration);
+                }
+            }else {
+                let to_send = bufchunk.len();
+
+                for (i, buf) in bufchunk.iter_mut().enumerate() {
+                    self.msgvec[i].msg_len = buf.len() as u32;
+                    self.iovecs[i].iov_base = buf.as_mut_ptr().cast::<libc::c_void>();
+                    self.iovecs[i].iov_len = buf.len();
+                }
+    
+                let nb_msg;
+                unsafe {
+                    nb_msg = libc::sendmmsg(
+                        self.socket.as_raw_fd(),
+                        self.msgvec.as_mut_ptr(),
+                        to_send as u32,
+                        0,
+                    );
+                }
+                if nb_msg == -1 {
+                    return Err(io::Error::new(io::ErrorKind::Other, "libc::sendmmsg"));
+                }
+                if nb_msg as usize != to_send {
+                    log::warn!("nb prepared messages doesn't match with nb sent messages");
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Hi,

I've introduced a feature to set bandwidth limits to prevent receiver overflow, an issue our system currently faces. 
This functionality, which I think will be beneficial to many, can be configured using the --bandwidth_limit parameter to define the maximum bandwidth in Mbit/s. 

I hope you consider integrating it.