### PR TITLE
Fix diode-file-bindings

### DIFF
--- a/diode-file-bindings/src/lib.rs
+++ b/diode-file-bindings/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(unsafe_code)]
 
-use diode::file;
+use diode::aux::{self,file};
 use std::{
     ffi::{c_char, CStr},
     net::SocketAddr,
@@ -14,7 +14,7 @@ use std::{
 pub unsafe extern "C" fn diode_new_config(
     ptr_addr: *const c_char,
     buffer_size: u32,
-) -> *mut file::Config<file::DiodeSend> {
+) -> *mut file::Config<aux::DiodeSend> {
     if ptr_addr.is_null() {
         return ptr::null_mut();
     }
@@ -23,7 +23,7 @@ pub unsafe extern "C" fn diode_new_config(
     let socket_addr = SocketAddr::from_str(&rust_addr).expect("ip:port");
 
     let config = Box::new(file::Config {
-        diode: file::DiodeSend::Tcp(socket_addr),
+        diode: aux::DiodeSend::Tcp(socket_addr),
         buffer_size: buffer_size as usize,
         hash: false,
     });
@@ -32,7 +32,7 @@ pub unsafe extern "C" fn diode_new_config(
 
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe extern "C" fn diode_free_config(ptr: *mut file::Config<file::DiodeSend>) {
+pub unsafe extern "C" fn diode_free_config(ptr: *mut file::Config<aux::DiodeSend>) {
     if ptr.is_null() {
         return;
     }
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn diode_free_config(ptr: *mut file::Config<file::DiodeSen
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn diode_send_file(
-    ptr: *mut file::Config<file::DiodeSend>,
+    ptr: *mut file::Config<aux::DiodeSend>,
     ptr_filepath: *const c_char,
 ) -> u32 {
     if ptr.is_null() {
@@ -64,19 +64,19 @@ pub unsafe extern "C" fn diode_send_file(
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn diode_receive_files(
-    ptr: *mut file::Config<file::DiodeSend>,
+    ptr: *mut file::Config<aux::DiodeSend>,
     ptr_odir: *const c_char,
 ) {
     if ptr.is_null() {
         return;
     }
     let config = unsafe { ptr.as_ref() }.expect("config");
-    let file::DiodeSend::Tcp(socket_addr) = config.diode else {
+    let aux::DiodeSend::Tcp(socket_addr) = config.diode else {
         return;
     };
 
     let config = file::Config {
-        diode: file::DiodeReceive {
+        diode: aux::DiodeReceive {
             from_tcp: Some(socket_addr),
             from_unix: None,
         },


### PR DESCRIPTION
The refactoring in commit 4ee0003e48e12207ad7650b09bf14b305883a844 was incomplete which caused the compilation of diode-file-bindings sub-project to fail. 