### PR TITLE
Fix (and merge) Dockerfiles, adds a CI job for building and uploading docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         id: docker_meta
         with:
           # images: docker.io/anssi/lidi-${{ matrix.lidi_service }}
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.lidi_service }}
+          images: ghcr.io/${{ github.repository }}-${{ matrix.lidi_service }}
           tags: |
               type=semver,pattern={{version}}
               type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,16 +36,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          # username: ${{ secrets.DOCKERHUB_USERNAME }}
-          # password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/metadata-action@v5
         id: docker_meta
         with:
-          # images: docker.io/anssi/lidi-${{ matrix.lidi_service }}
-          images: ghcr.io/${{ github.repository }}-${{ matrix.lidi_service }}
+          images: docker.io/anssi/lidi-${{ matrix.lidi_service }}
           tags: |
               type=semver,pattern={{version}}
               type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,37 @@ jobs:
           bin: diode-send,diode-receive,diode-send-file,diode-receive-file
           archive: lidi-$tag
           token: ${{ secrets.GITHUB_TOKEN }}
+  build-and-push-docker-image:
+    name: Builds and pushes a tagged docker image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lidi_service:
+          - send
+          - receive
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          # username: ${{ secrets.DOCKERHUB_USERNAME }}
+          # password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: docker_meta
+        with:
+          images: docker.io/anssi/lidi-${{ matrix.lidi_service }}
+          tags: |
+              type=semver,pattern={{version}}
+              type=semver,pattern={{major}}.{{minor}}
+              type=semver,pattern={{major}}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          target: ${{ matrix.lidi_service }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+      
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,8 @@ jobs:
       - uses: docker/metadata-action@v5
         id: docker_meta
         with:
-          images: docker.io/anssi/lidi-${{ matrix.lidi_service }}
+          # images: docker.io/anssi/lidi-${{ matrix.lidi_service }}
+          images: ${{ vars.GITHUB_REPOSITORY_OWNER }}/lidi-${{ matrix.lidi_service }}
           tags: |
               type=semver,pattern={{version}}
               type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         id: docker_meta
         with:
           # images: docker.io/anssi/lidi-${{ matrix.lidi_service }}
-          images: ${{ vars.GITHUB_REPOSITORY_OWNER }}/lidi-${{ matrix.lidi_service }}
+          images: guillaumedsde/lidi-${{ matrix.lidi_service }}
           tags: |
               type=semver,pattern={{version}}
               type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         id: docker_meta
         with:
           # images: docker.io/anssi/lidi-${{ matrix.lidi_service }}
-          images: guillaumedsde/lidi-${{ matrix.lidi_service }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.lidi_service }}
           tags: |
               type=semver,pattern={{version}}
               type=semver,pattern={{major}}.{{minor}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:latest AS builder
+
+WORKDIR /usr/src/lidi
+COPY . .
+RUN cargo install --path .
+
+# NOTE: use Google's "distroless with glibc" base image, see:
+#       https://github.com/GoogleContainerTools/distroless/blob/6755e21ccd99ddead6edc8106ba03888cbeed41a/cc/README.md
+FROM gcr.io/distroless/cc:latest AS send
+
+COPY --from=builder /usr/local/cargo/bin/diode-send /usr/local/bin/
+ENTRYPOINT ["diode-send"]
+
+FROM gcr.io/distroless/cc:latest AS receive
+
+COPY --from=builder /usr/local/cargo/bin/diode-receive /usr/local/bin/
+ENTRYPOINT ["diode-receive"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
+# NOTE: use Google's "distroless with libgcc1" base image, see:
+#       https://github.com/GoogleContainerTools/distroless/blob/6755e21ccd99ddead6edc8106ba03888cbeed41a/cc/README.md
+ARG BASE_IMAGE_FINAL_STAGES="gcr.io/distroless/cc:latest"
+
 FROM rust:1-bookworm AS builder
 
 WORKDIR /usr/src/lidi
 COPY . .
 RUN cargo install --path .
 
-# NOTE: use Google's "distroless with glibc" base image, see:
-#       https://github.com/GoogleContainerTools/distroless/blob/6755e21ccd99ddead6edc8106ba03888cbeed41a/cc/README.md
-FROM gcr.io/distroless/cc:latest AS send
+FROM ${BASE_IMAGE_FINAL_STAGES} AS send
 
 COPY --from=builder /usr/local/cargo/bin/diode-send /usr/local/bin/
 ENTRYPOINT ["diode-send"]
 
-FROM gcr.io/distroless/cc:latest AS receive
+FROM ${BASE_IMAGE_FINAL_STAGES} AS receive
 
 COPY --from=builder /usr/local/cargo/bin/diode-receive /usr/local/bin/
 ENTRYPOINT ["diode-receive"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # NOTE: use Google's "distroless with libgcc1" base image, see:
 #       https://github.com/GoogleContainerTools/distroless/blob/6755e21ccd99ddead6edc8106ba03888cbeed41a/cc/README.md
-ARG BASE_IMAGE_FINAL_STAGES="gcr.io/distroless/cc:latest"
+ARG BASE_IMAGE_FINAL_STAGES="gcr.io/distroless/cc:nonroot"
 
 FROM rust:1-bookworm AS builder
 
@@ -10,10 +10,10 @@ RUN cargo install --path .
 
 FROM ${BASE_IMAGE_FINAL_STAGES} AS send
 
-COPY --from=builder /usr/local/cargo/bin/diode-send /usr/local/bin/
+COPY --from=builder --chown=root:root --chmod=755 /usr/local/cargo/bin/diode-send /usr/local/bin/
 ENTRYPOINT ["diode-send"]
 
 FROM ${BASE_IMAGE_FINAL_STAGES} AS receive
 
-COPY --from=builder /usr/local/cargo/bin/diode-receive /usr/local/bin/
+COPY --from=builder --chown=root:root --chmod=755 /usr/local/cargo/bin/diode-receive /usr/local/bin/
 ENTRYPOINT ["diode-receive"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest AS builder
+FROM rust:1-bookworm AS builder
 
 WORKDIR /usr/src/lidi
 COPY . .

--- a/Dockerfile.receive
+++ b/Dockerfile.receive
@@ -1,8 +1,0 @@
-FROM rust:latest AS builder
-WORKDIR /usr/src/lidi
-COPY . .
-RUN cargo install --path .
-
-FROM debian:buster-slim
-COPY --from=builder /usr/local/cargo/bin/diode-receive /usr/local/bin
-ENTRYPOINT ["diode-receive"]

--- a/Dockerfile.send
+++ b/Dockerfile.send
@@ -1,8 +1,0 @@
-FROM rust:latest AS builder
-WORKDIR /usr/src/lidi
-COPY . .
-RUN cargo install --path .
-
-FROM debian:buster-slim
-COPY --from=builder /usr/local/cargo/bin/diode-send /usr/local/bin
-ENTRYPOINT ["diode-send"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
     image: diode:send
     build:
       context: .
-      dockerfile: Dockerfile.send
+      dockerfile: Dockerfile
+      target: send
     networks:
       diode_net:
         ipv4_address: 172.16.0.2
@@ -31,7 +32,8 @@ services:
     image: diode:receive
     build:
       context: .
-      dockerfile: Dockerfile.receive
+      dockerfile: Dockerfile
+      target: receive
     networks:
       diode_net:
         ipv4_address: 172.16.0.3


### PR DESCRIPTION
## :memo:  Description

Hello :wave: 

This PR corrects an issue with the repository's Dockerfiles: the final images don't include the glibc dependency due to them using the slim variant of the debian image as the base.
The consequence of this is that the lidis/r binaries crash on startup when running the docker images built from this repository's Dockerfiles, moreover no docker image is published on the docker hub.

Note that it might be desirable to squash the commits when merging, the commit history is ok, but not ideal

## :heavy_check_mark:  Changelog

The PR addresses this by:

- rewriting the Dockerfiles into a single multi-stage Dockerfile (one stage for the send binary, another for the receive binary)
- using [one of](https://github.com/GoogleContainerTools/distroless/blob/6755e21ccd99ddead6edc8106ba03888cbeed41a/cc/README.md) Google's ["distroless"](https://github.com/GoogleContainerTools/distroless) docker image as the base for the final images.
  - [the CC image used here, includes](https://github.com/GoogleContainerTools/distroless/blob/6755e21ccd99ddead6edc8106ba03888cbeed41a/cc/README.md)
    - ca-certificates
    - A /etc/passwd entry for a root user
    - A /tmp directory
    - tzdata
    - glibc
    - libgcc1 and its dependencies.
- switching to a non-root user for the final docker images
- adding a CI job for building, tagging and publishing the final two docker images (send/receive) to the dockerhub
  - note that the username/password variable names for logging into the dockerhub  are [the same ones as used in eurydice](https://github.com/ANSSI-FR/eurydice/blob/fecff0ab79c886853e0cd3fba918e134dbcbb809/.github/workflows/ci.yml#L71-L72) and they should [be added in the lidi's github repository's configuration](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository) 

## :lab_coat:  Tests

Note that I have tested the Github action logic for build, tagging and pushing the docker images but in my own fork (since I don't have access to this repo's CI). During my tests (which consisted of building and uploading the image's to my repo's github registry) [everything worked as exepcted](https://github.com/guillaumedsde/lidi/actions/runs/11879537422).