### PR TITLE
Lidi v1.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,10 +59,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
+name = "bitflags"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "cfg-if"
@@ -78,18 +78,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -143,7 +143,7 @@ dependencies = [
  "fasthash",
  "libc",
  "log",
- "rand 0.8.5",
+ "rand 0.9.0",
  "raptorq",
  "simplelog",
 ]
@@ -191,12 +191,13 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
+ "r-efi",
  "wasi",
 ]
 
@@ -208,21 +209,21 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "num-conv"
@@ -250,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "powerfmt"
@@ -262,30 +263,36 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -302,23 +309,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
+ "zerocopy",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -338,9 +345,9 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
@@ -368,18 +375,18 @@ checksum = "58f57ca1d128a43733fd71d583e837b1f22239a37ebea09cde11d8d9a9080f47"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -405,9 +412,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -425,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -442,15 +449,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -458,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "utf8parse"
@@ -470,9 +477,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "winapi"
@@ -579,6 +589,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "xoroshiro128"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,19 +608,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "diode"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "clap",
  "crossbeam-channel",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "diode-file-bindings"
-version = "1.3.1"
+version = "1.3.5"
 dependencies = [
  "diode",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
 ]
@@ -221,9 +221,9 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "num-conv"
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.39"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -449,15 +449,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.20"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lto = true
 debug = false
 strip = true
 panic = "abort"
+codegen-units = 1
 
 [workspace]
 members = [".", "diode-file-bindings"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diode"
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 license = "GPL-3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diode"
 version = "1.3.5"
-edition = "2021"
+edition = "2024"
 license = "GPL-3.0"
 
 [dependencies]

--- a/diode-file-bindings/Cargo.toml
+++ b/diode-file-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diode-file-bindings"
-version = "1.3.1"
+version = "1.3.5"
 edition = "2021"
 license = "GPL-3.0"
 

--- a/diode-file-bindings/Cargo.toml
+++ b/diode-file-bindings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "diode-file-bindings"
 version = "1.3.5"
-edition = "2021"
+edition = "2024"
 license = "GPL-3.0"
 
 [dependencies]

--- a/diode-file-bindings/src/lib.rs
+++ b/diode-file-bindings/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
     str::FromStr,
 };
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn diode_new_config(
     ptr_addr: *const c_char,
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn diode_new_config(
     Box::into_raw(config)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn diode_free_config(ptr: *mut file::Config<aux::DiodeSend>) {
     if ptr.is_null() {
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn diode_free_config(ptr: *mut file::Config<aux::DiodeSend
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn diode_send_file(
     ptr: *mut file::Config<aux::DiodeSend>,
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn diode_send_file(
     file::send::send_file(config, &rust_filepath).unwrap_or(0) as u32
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn diode_receive_files(
     ptr: *mut file::Config<aux::DiodeSend>,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@
 project = 'Lidi'
 copyright = '2023, ANSSI-FR'
 author = 'ANSSI-FR'
-release = '1.3.4'
+release = '1.3.5'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/bin/diode-flood-test.rs
+++ b/src/bin/diode-flood-test.rs
@@ -58,7 +58,7 @@ fn start<D>(mut diode: D, buffer_size: usize)
 where
     D: Write,
 {
-    let mut thread_rng = rand::thread_rng();
+    let mut thread_rng = rand::rng();
     let mut buffer = vec![0u8; buffer_size];
     thread_rng.fill_bytes(&mut buffer);
 

--- a/src/receive/client.rs
+++ b/src/receive/client.rs
@@ -61,7 +61,9 @@ where
                         return Ok(());
                     }
                     protocol::MessageType::End => {
-                        log::info!("client {client_id:x}: finished transfer, {transmitted} bytes transmitted");
+                        log::info!(
+                            "client {client_id:x}: finished transfer, {transmitted} bytes transmitted"
+                        );
                         client.flush()?;
                         return Ok(());
                     }

--- a/src/receive/reblock.rs
+++ b/src/receive/reblock.rs
@@ -83,7 +83,9 @@ pub(crate) fn start<F>(receiver: &receive::Receiver<F>) -> Result<(), receive::E
             }
 
             if message_block_id != block_id.wrapping_add(1) {
-                log::warn!("discarding packet with block_id {message_block_id} (current block_id is {block_id})");
+                log::warn!(
+                    "discarding packet with block_id {message_block_id} (current block_id is {block_id})"
+                );
                 continue;
             }
 

--- a/src/receive/reordering.rs
+++ b/src/receive/reordering.rs
@@ -55,7 +55,9 @@ pub(crate) fn start<F>(receiver: &receive::Receiver<F>) -> Result<(), receive::E
             .replace(message)
             .is_some()
         {
-            log::error!("received a new block {block_id} but existing one was not sent to dispatch, synchronization lost, dropping everything");
+            log::error!(
+                "received a new block {block_id} but existing one was not sent to dispatch, synchronization lost, dropping everything"
+            );
             pending_messages.fill_with(|| None);
             receiver.to_dispatch.send(None)?;
         }

--- a/src/sock_utils.rs
+++ b/src/sock_utils.rs
@@ -12,14 +12,16 @@ pub fn set_socket_recv_buffer_size<S: AsRawFd>(socket: &S, size: i32) -> Result<
 }
 
 unsafe fn setsockopt_buffer_size(fd: i32, size: i32, option_name: i32) -> Result<(), io::Error> {
-    let res = unsafe { libc::setsockopt(
-        fd,
-        libc::SOL_SOCKET,
-        option_name,
-        ptr::addr_of!(size).cast::<libc::c_void>(),
-        mem::size_of::<libc::c_int>() as libc::socklen_t,
-    ) };
-    
+    let res = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            option_name,
+            ptr::addr_of!(size).cast::<libc::c_void>(),
+            mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+
     if res == 0 {
         Ok(())
     } else {
@@ -38,13 +40,15 @@ pub fn get_socket_recv_buffer_size<S: AsRawFd>(socket: &S) -> Result<i32, io::Er
 unsafe fn getsockopt_buffer_size(fd: i32, option_name: i32) -> Result<i32, io::Error> {
     let mut sz = 0i32;
     let mut len = mem::size_of::<libc::c_int>() as libc::socklen_t;
-    let res = unsafe { libc::getsockopt(
-        fd,
-        libc::SOL_SOCKET,
-        option_name,
-        ptr::addr_of_mut!(sz).cast::<libc::c_void>(),
-        &mut len,
-    ) };
+    let res = unsafe {
+        libc::getsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            option_name,
+            ptr::addr_of_mut!(sz).cast::<libc::c_void>(),
+            &mut len,
+        )
+    };
     if res == 0 {
         Ok(sz)
     } else {

--- a/src/sock_utils.rs
+++ b/src/sock_utils.rs
@@ -12,17 +12,18 @@ pub fn set_socket_recv_buffer_size<S: AsRawFd>(socket: &S, size: i32) -> Result<
 }
 
 unsafe fn setsockopt_buffer_size(fd: i32, size: i32, option_name: i32) -> Result<(), io::Error> {
-    let res = libc::setsockopt(
+    let res = unsafe { libc::setsockopt(
         fd,
         libc::SOL_SOCKET,
         option_name,
         ptr::addr_of!(size).cast::<libc::c_void>(),
         mem::size_of::<libc::c_int>() as libc::socklen_t,
-    );
+    ) };
+    
     if res == 0 {
         Ok(())
     } else {
-        Err(io::Error::new(io::ErrorKind::Other, "libc::setsockopt"))
+        Err(io::Error::other("libc::setsockopt"))
     }
 }
 
@@ -37,16 +38,16 @@ pub fn get_socket_recv_buffer_size<S: AsRawFd>(socket: &S) -> Result<i32, io::Er
 unsafe fn getsockopt_buffer_size(fd: i32, option_name: i32) -> Result<i32, io::Error> {
     let mut sz = 0i32;
     let mut len = mem::size_of::<libc::c_int>() as libc::socklen_t;
-    let res = libc::getsockopt(
+    let res = unsafe { libc::getsockopt(
         fd,
         libc::SOL_SOCKET,
         option_name,
         ptr::addr_of_mut!(sz).cast::<libc::c_void>(),
         &mut len,
-    );
+    ) };
     if res == 0 {
         Ok(sz)
     } else {
-        Err(io::Error::new(io::ErrorKind::Other, "libc::getsockopt"))
+        Err(io::Error::other("libc::getsockopt"))
     }
 }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -125,7 +125,7 @@ impl UdpMessages<UdpRecv> {
         };
 
         if nb_msg == -1 {
-            Err(io::Error::new(io::ErrorKind::Other, "libc::recvmmsg"))
+            Err(io::Error::other("libc::recvmmsg"))
         } else {
             Ok(self
                 .buffers
@@ -163,7 +163,7 @@ impl UdpMessages<UdpSend> {
                     }
 
                     if nb_msg == -1 {
-                        return Err(io::Error::new(io::ErrorKind::Other, "libc::sendmmsg"));
+                        return Err(io::Error::other("libc::sendmmsg"));
                     }
 
                     let send_duration = start_time.elapsed().as_secs_f64();
@@ -197,7 +197,7 @@ impl UdpMessages<UdpSend> {
                     );
                 }
                 if nb_msg == -1 {
-                    return Err(io::Error::new(io::ErrorKind::Other, "libc::sendmmsg"));
+                    return Err(io::Error::other("libc::sendmmsg"));
                 }
                 if nb_msg as usize != to_send {
                     log::warn!("nb prepared messages doesn't match with nb sent messages");


### PR DESCRIPTION
 - Bump rust edition to 2024
 - Fix Clippy warnings: Clean up returning errors using io::Error::other()
 -  Mark no_mangle attribute as unsafe (see https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html)
 -  Mark direct calls to libc::setsockopt() as unsafe
 - Bump documentation release to 1.3.5
 -  Format sources

