### PR TITLE
Add anssi metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to This Project
+
+Thank you for your interest in this project. Please read this document
+carefully before considering any contributions.
+
+## Scope of Contributions
+
+This project only accepts contributions related to security maintenance. No
+other types of contributions are expected or will be accepted at this time.
+
+## Support Policy
+
+Thank you for understanding and respecting the limited scope of this project's
+contributions and support. In particular, there is no commitment regarding
+processing times.
+
+### Limited Support Scope
+
+- Support is provided exclusively to contributors working on security-related
+  improvements.
+- The project maintainers will only assist with issues directly related to your
+  security maintenance contributions.
+
+### No General Support
+
+- We do not offer general support for using or setting up the project.
+- Questions, feature requests, or issues unrelated to active security
+  maintenance contributions will not be addressed.
+
+## How to Contribute
+
+1. Ensure your contribution is strictly related to security maintenance.
+2. Fork the repository and create a new branch for your work.
+3. Submit a pull request with a clear description of your security-related
+   improvements.
+
+## Security Vulnerabilities
+
+If you discover a security vulnerability, please report it according to our
+security policy outlined in the [`SECURITY.md`](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # lidi
 
+[![badge_repo](https://img.shields.io/badge/ANSSI--FR-lidi-white)](https://github.com/ANSSI-FR/lidi)
+[![badge_catégorie_interne](https://img.shields.io/badge/catégorie-interne-%23d08fce)](https://github.com/ANSSI-FR#types-de-projets)
+[![openess_badge_B](https://img.shields.io/badge/code.gouv.fr-open-green)](https://documentation.ouvert.numerique.gouv.fr/les-parcours-de-documentation/ouvrir-un-projet-num%C3%A9rique/#niveau-ouverture)
 [![Github CI](https://github.com/ANSSI-FR/lidi/workflows/Rust/badge.svg)](https://github.com/ANSSI-FR/lidi/actions)
 [![Github CI](https://github.com/ANSSI-FR/lidi/workflows/Clippy/badge.svg)](https://github.com/ANSSI-FR/lidi/actions)
+
+## French Cybersecurity Agency (ANSSI)
+
+<img src="https://www.sgdsn.gouv.fr/files/styles/ds_image_paragraphe/public/files/Notre_Organisation/logo_anssi.png" alt="ANSSI logo" width="20%">
+
+*This projet is managed by [ANSSI](https://cyber.gouv.fr/). To find out more,
+you can go to the
+[page](https://cyber.gouv.fr/enjeux-technologiques/open-source/) (in French)
+dedicated to the ANSSI open source strategy. You can also click on the badges
+above to learn more about their meaning*
 
 ## What is lidi?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please help us
+address it responsibly by following these steps:
+
+1. **Do not publicly disclose the vulnerability.**
+2. Contact us directly at
+   [opensource@ssi.gouv.fr](mailto:opensource@ssi.gouv.fr) with the following
+   details:
+   - A clear description of the issue.
+   - Steps to reproduce the vulnerability.
+   - Any potential impact or exploit scenarios.
+
+Thank you for helping us keep this project secure!


### PR DESCRIPTION
Hey,

here's a proposal to add some metadata to the repository (badges, link to ANSSI open source strategy, CONTRIBUTING/SECURITY) and align it to the graphical identity of the ANSSI repositories.

I mark the PR as draft because you might want to double check some things before merging:

- the openness level badge and the CONTRIBUTING document
- the contacts indicated in SECURITY (and the way to actually provide feedback)

Feel free to ask any question on this.