### PR TITLE
Add embedded observability HTTP frontend for pitcher and catcher

### DIFF
--- a/src/bin/diode-oneshot-receive.rs
+++ b/src/bin/diode-oneshot-receive.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use diode::{protocol, receive};
-use std::{io, net, process, str::FromStr, thread, time};
+use diode::{protocol, receive, stats};
+use std::{io, net, process, str::FromStr, sync, thread, time};
 
 fn parse_duration_seconds(input: &str) -> Result<time::Duration, <u64 as FromStr>::Err> {
     let input = input.parse()?;
@@ -110,6 +110,7 @@ fn main() {
             }
         };
 
+    let receiver_stats = sync::Arc::new(stats::Stats::new(stats::ROLE_RECEIVE, 32));
     let receiver = match receive::Receiver::new(
         receive::Config {
             from: args.from,
@@ -125,6 +126,7 @@ fn main() {
             hash: args.hash,
         },
         raptorq,
+        receiver_stats,
         |_| Ok::<_, io::Error>(io::stdout()),
         |_, ok| {
             if ok {

--- a/src/bin/diode-oneshot-send.rs
+++ b/src/bin/diode-oneshot-send.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use diode::{protocol, send};
+use diode::{protocol, send, stats};
 use std::{io, net, process, sync, thread};
 
 #[derive(clap::Parser)]
@@ -91,6 +91,7 @@ fn main() {
         }
     };
 
+    let sender_stats = sync::Arc::new(stats::Stats::new(stats::ROLE_SEND, 32));
     let sender = match send::Sender::new(
         send::Config {
             max_clients: 1,
@@ -105,6 +106,7 @@ fn main() {
             hash: args.hash,
         },
         raptorq,
+        sender_stats,
     ) {
         Ok(sender) => sender,
         Err(e) => {

--- a/src/bin/diode-receive.rs
+++ b/src/bin/diode-receive.rs
@@ -1,12 +1,12 @@
 use clap::Parser;
-use diode::{protocol, receive};
+use diode::{http, protocol, receive, stats};
 use std::{
     io::{self, Write},
     net,
     os::{fd::AsRawFd, unix},
     path,
     str::FromStr,
-    thread, time,
+    sync, thread, time,
 };
 
 fn parse_duration_seconds(input: &str) -> Result<time::Duration, <u64 as FromStr>::Err> {
@@ -47,6 +47,12 @@ struct Args {
         help = "Log messages in a file instead of the console"
     )]
     log_file: Option<path::PathBuf>,
+    #[clap(
+        value_name = "ip:port",
+        long,
+        help = "Bind a read-only observability HTTP server on this address (bind to 127.0.0.1; no auth)"
+    )]
+    http_addr: Option<net::SocketAddr>,
     #[clap(
         value_name = "ip:port",
         long,
@@ -177,13 +183,41 @@ impl TryFrom<&Clients> for Client {
     }
 }
 
+fn build_info(args: &Args) -> http::InfoSnapshot {
+    http::InfoSnapshot {
+        role: stats::ROLE_RECEIVE,
+        version: env!("CARGO_PKG_VERSION"),
+        max_clients: args.max_clients,
+        block_bytes: args.block,
+        repair_pct: args.repair,
+        heartbeat_secs: args.heartbeat.map(|d| d.as_secs()),
+        mtu: args.from_mtu,
+        peer: Some(args.from),
+        bind: None,
+        listener_tcp: None,
+        listener_unix: None,
+        forward_tcp: args.to.to_tcp,
+        forward_unix: args.to.to_unix.clone(),
+        flush: args.flush,
+        hash: args.hash,
+    }
+}
+
 fn main() {
     let args = Args::parse();
 
-    if let Err(e) = diode::init_logger(args.log_level, args.log_file, false) {
-        eprintln!("failed to initialize logger: {e}");
-        return;
-    }
+    let log_ring = match diode::init_logger_with_ring(
+        args.log_level,
+        args.log_file.clone(),
+        false,
+        args.http_addr.is_some(),
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("failed to initialize logger: {e}");
+            return;
+        }
+    };
 
     log::info!(
         "{} version {}",
@@ -200,6 +234,25 @@ fn main() {
             }
         };
 
+    let receiver_stats = sync::Arc::new(stats::Stats::new(
+        stats::ROLE_RECEIVE,
+        (args.max_clients as usize).saturating_mul(8).max(32),
+    ));
+    let info = sync::Arc::new(build_info(&args));
+
+    if let Some(http_addr) = args.http_addr {
+        let stats_handle = sync::Arc::clone(&receiver_stats);
+        let info_handle = sync::Arc::clone(&info);
+        // Detached: the HTTP server outlives scoped-thread shutdown (the OS
+        // reaps it when `main` returns).
+        thread::Builder::new()
+            .name("http_server".into())
+            .spawn(move || {
+                http::start(http_addr, &stats_handle, &info_handle, log_ring.as_ref());
+            })
+            .expect("thread spawn");
+    }
+
     let receiver = match receive::Receiver::new(
         receive::Config {
             from: args.from,
@@ -215,6 +268,7 @@ fn main() {
             hash: args.hash,
         },
         raptorq,
+        sync::Arc::clone(&receiver_stats),
         |_| Client::try_from(&args.to),
         |_, _| (),
     ) {

--- a/src/bin/diode-send.rs
+++ b/src/bin/diode-send.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use diode::{protocol, send};
+use diode::{http, protocol, send, stats};
 use std::{
     io::Read,
     net,
@@ -47,6 +47,12 @@ struct Args {
         help = "Log messages in a file instead of the console"
     )]
     log_file: Option<path::PathBuf>,
+    #[clap(
+        value_name = "ip:port",
+        long,
+        help = "Bind a read-only observability HTTP server on this address (bind to 127.0.0.1; no auth)"
+    )]
+    http_addr: Option<net::SocketAddr>,
     #[clap(flatten)]
     from: Listeners,
     #[clap(
@@ -174,13 +180,91 @@ fn tcp_listener_loop(listener: &net::TcpListener, sender: &send::Sender<Client>)
     }
 }
 
+fn bind_tcp(from_tcp: Option<net::SocketAddr>) -> Result<Option<net::TcpListener>, ()> {
+    let Some(addr) = from_tcp else {
+        return Ok(None);
+    };
+    match net::TcpListener::bind(addr) {
+        Err(e) => {
+            log::error!("failed to bind TCP {addr}: {e}");
+            Err(())
+        }
+        Ok(listener) => {
+            log::info!("accepting TCP clients on {addr}");
+            Ok(Some(listener))
+        }
+    }
+}
+
+fn bind_unix(from_unix: Option<path::PathBuf>) -> Result<Option<unix::net::UnixListener>, ()> {
+    let Some(path) = from_unix else {
+        return Ok(None);
+    };
+    if path.exists() {
+        log::error!("Unix socket path '{}' already exists", path.display());
+        return Err(());
+    }
+    match unix::net::UnixListener::bind(&path) {
+        Err(e) => {
+            log::error!("failed to bind Unix {}: {e}", path.display());
+            Err(())
+        }
+        Ok(listener) => {
+            log::info!("accepting Unix clients at {}", path.display());
+            Ok(Some(listener))
+        }
+    }
+}
+
+fn spawn_http(
+    addr: net::SocketAddr,
+    stats: sync::Arc<diode::stats::Stats>,
+    info: sync::Arc<http::InfoSnapshot>,
+    log_ring: Option<sync::Arc<diode::logring::LogRing>>,
+) {
+    // Detached: the HTTP server outlives scoped-thread shutdown (the OS reaps
+    // it when `main` returns).
+    thread::Builder::new()
+        .name("http_server".into())
+        .spawn(move || http::start(addr, &stats, &info, log_ring.as_ref()))
+        .expect("thread spawn");
+}
+
+fn build_info(args: &Args) -> http::InfoSnapshot {
+    http::InfoSnapshot {
+        role: stats::ROLE_SEND,
+        version: env!("CARGO_PKG_VERSION"),
+        max_clients: args.max_clients,
+        block_bytes: args.block,
+        repair_pct: args.repair,
+        heartbeat_secs: args.heartbeat.map(|d| d.as_secs()),
+        mtu: args.to_mtu,
+        peer: Some(args.to),
+        bind: Some(args.to_bind),
+        listener_tcp: args.from.from_tcp,
+        listener_unix: args.from.from_unix.clone(),
+        forward_tcp: None,
+        forward_unix: None,
+        flush: args.flush,
+        hash: args.hash,
+    }
+}
+
 fn main() {
     let args = Args::parse();
 
-    if let Err(e) = diode::init_logger(args.log_level, args.log_file, false) {
-        eprintln!("failed to initialize logger: {e}");
-        return;
-    }
+    let log_ring = match diode::init_logger_with_ring(
+        args.log_level,
+        args.log_file.clone(),
+        false,
+        args.http_addr.is_some(),
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("failed to initialize logger: {e}");
+            return;
+        }
+    };
 
     log::info!(
         "{} version {}",
@@ -196,6 +280,12 @@ fn main() {
         }
     };
 
+    let sender_stats = sync::Arc::new(stats::Stats::new(
+        stats::ROLE_SEND,
+        (args.max_clients as usize).saturating_mul(8).max(32),
+    ));
+    let info = sync::Arc::new(build_info(&args));
+
     let sender = match send::Sender::new(
         send::Config {
             max_clients: args.max_clients,
@@ -210,6 +300,7 @@ fn main() {
             hash: args.hash,
         },
         raptorq,
+        sync::Arc::clone(&sender_stats),
     ) {
         Ok(sender) => sender,
         Err(e) => {
@@ -218,42 +309,23 @@ fn main() {
         }
     };
 
-    let tcp_listener = match args.from.from_tcp {
-        None => None,
-        Some(from_tcp) => match net::TcpListener::bind(from_tcp) {
-            Err(e) => {
-                log::error!("failed to bind TCP {from_tcp}: {e}");
-                return;
-            }
-            Ok(listener) => {
-                log::info!("accepting TCP clients on {from_tcp}");
-                Some(listener)
-            }
-        },
+    let Ok(tcp_listener) = bind_tcp(args.from.from_tcp) else {
+        return;
     };
-
-    let unix_listener = match args.from.from_unix {
-        None => None,
-        Some(from_unix) => {
-            if from_unix.exists() {
-                log::error!("Unix socket path '{}' already exists", from_unix.display());
-                return;
-            }
-
-            match unix::net::UnixListener::bind(&from_unix) {
-                Err(e) => {
-                    log::error!("failed to bind Unix {}: {e}", from_unix.display());
-                    return;
-                }
-                Ok(listener) => {
-                    log::info!("accepting Unix clients at {}", from_unix.display());
-                    Some(listener)
-                }
-            }
-        }
+    let Ok(unix_listener) = bind_unix(args.from.from_unix.clone()) else {
+        return;
     };
 
     let sender = sync::Arc::new(sender);
+
+    if let Some(http_addr) = args.http_addr {
+        spawn_http(
+            http_addr,
+            sync::Arc::clone(&sender_stats),
+            sync::Arc::clone(&info),
+            log_ring,
+        );
+    }
 
     thread::scope(|scope| {
         let lsender = sender.clone();

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,452 @@
+//! Minimal, dependency-free HTTP/1.1 server that exposes a read-only
+//! observability UI for a single `diode-send` or `diode-receive` instance.
+//!
+//! This intentionally does not pull in a full HTTP crate or an async runtime.
+//! The schemas are tiny, fully controlled by us, and serialised by a hand-rolled
+//! JSON writer. Concurrency is single-threaded: the UI polls at 1 Hz and
+//! handlers are sub-millisecond.
+//!
+//! Routes served when bound:
+//! - `GET /`            → embedded `index.html`
+//! - `GET /api/info`    → static config snapshot
+//! - `GET /api/status`  → live counters + active clients
+//! - `GET /api/logs`    → recent log lines (optional `?since=<u64>`)
+
+use std::{
+    fmt::Write as FmtWrite,
+    io::{BufRead, BufReader, Read, Write},
+    net::{self, SocketAddr, TcpListener, TcpStream},
+    path,
+    sync::Arc,
+    time::Duration,
+};
+
+use crate::{
+    logring::LogRing,
+    stats::{ClientEntry, Stats, StatsSnapshot},
+};
+
+const INDEX_HTML: &str = include_str!("web/index.html");
+
+const READ_TIMEOUT: Duration = Duration::from_secs(2);
+const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_REQUEST_BYTES: usize = 8 * 1024;
+
+/// Static configuration captured once at startup and echoed to the UI.
+pub struct InfoSnapshot {
+    pub role: &'static str,
+    pub version: &'static str,
+    pub max_clients: u32,
+    pub block_bytes: u32,
+    pub repair_pct: u32,
+    pub heartbeat_secs: Option<u64>,
+    pub mtu: u16,
+    pub peer: Option<SocketAddr>,
+    pub bind: Option<SocketAddr>,
+    pub listener_tcp: Option<SocketAddr>,
+    pub listener_unix: Option<path::PathBuf>,
+    pub forward_tcp: Option<SocketAddr>,
+    pub forward_unix: Option<path::PathBuf>,
+    pub flush: bool,
+    pub hash: bool,
+}
+
+/// Bind and run the HTTP server on `addr`. If `log_ring` is `Some`, the
+/// `/api/logs` endpoint serves entries from it; otherwise it returns an empty
+/// list.
+///
+/// Returns once the listener stops accepting (which currently only happens on
+/// fatal I/O error). The caller typically spawns this on a dedicated thread.
+pub fn start(
+    addr: SocketAddr,
+    stats: &Arc<Stats>,
+    info: &Arc<InfoSnapshot>,
+    log_ring: Option<&Arc<LogRing>>,
+) {
+    let listener = match TcpListener::bind(addr) {
+        Ok(l) => l,
+        Err(e) => {
+            log::error!("observability HTTP failed to bind {addr}: {e}");
+            return;
+        }
+    };
+    log::info!("observability HTTP listening on http://{addr}/");
+
+    let ring_ref = log_ring.map(AsRef::as_ref);
+    for conn in listener.incoming() {
+        match conn {
+            Ok(stream) => handle(stream, stats, info, ring_ref),
+            Err(e) => {
+                log::warn!("observability HTTP accept error: {e}");
+            }
+        }
+    }
+}
+
+fn handle(
+    mut stream: TcpStream,
+    stats: &Stats,
+    info: &InfoSnapshot,
+    log_ring: Option<&LogRing>,
+) {
+    let _ = stream.set_read_timeout(Some(READ_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(WRITE_TIMEOUT));
+    let _ = stream.set_nodelay(true);
+
+    let request = match read_request(&stream) {
+        Ok(r) => r,
+        Err(e) => {
+            log::debug!("observability HTTP read error: {e}");
+            return;
+        }
+    };
+
+    let (method, target) = parse_request_line(&request);
+    if method != "GET" {
+        write_response(
+            &mut stream,
+            405,
+            "Method Not Allowed",
+            "application/json; charset=utf-8",
+            br#"{"error":"method not allowed"}"#,
+        );
+        return;
+    }
+
+    let (path, query) = split_query(target);
+
+    match path {
+        "/" => write_response(
+            &mut stream,
+            200,
+            "OK",
+            "text/html; charset=utf-8",
+            INDEX_HTML.as_bytes(),
+        ),
+        "/api/info" => {
+            let body = render_info(info);
+            write_response(
+                &mut stream,
+                200,
+                "OK",
+                "application/json; charset=utf-8",
+                body.as_bytes(),
+            );
+        }
+        "/api/status" => {
+            let snapshot = stats.snapshot();
+            let body = render_status(stats.role, &snapshot);
+            write_response(
+                &mut stream,
+                200,
+                "OK",
+                "application/json; charset=utf-8",
+                body.as_bytes(),
+            );
+        }
+        "/api/logs" => {
+            let since = parse_since(query);
+            let body = render_logs(log_ring, since);
+            write_response(
+                &mut stream,
+                200,
+                "OK",
+                "application/json; charset=utf-8",
+                body.as_bytes(),
+            );
+        }
+        _ => write_response(
+            &mut stream,
+            404,
+            "Not Found",
+            "application/json; charset=utf-8",
+            br#"{"error":"not found"}"#,
+        ),
+    }
+}
+
+fn read_request(stream: &TcpStream) -> std::io::Result<String> {
+    let mut reader = BufReader::new(stream).take(MAX_REQUEST_BYTES as u64);
+    let mut head = String::new();
+    // Read lines until the blank CRLF that ends the header block. The browser
+    // still sends headers even though we ignore them; we just need to drain
+    // them so the socket is ready for the response.
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line)?;
+        if n == 0 {
+            break;
+        }
+        if line == "\r\n" || line == "\n" {
+            if head.is_empty() {
+                // Client sent only CRLF: treat as an empty line preceding the
+                // request. Loop again.
+                continue;
+            }
+            break;
+        }
+        if head.is_empty() {
+            head.push_str(&line);
+        }
+    }
+    Ok(head)
+}
+
+fn parse_request_line(line: &str) -> (&str, &str) {
+    let line = line.trim_end_matches(['\r', '\n']);
+    let mut parts = line.splitn(3, ' ');
+    let method = parts.next().unwrap_or("");
+    let target = parts.next().unwrap_or("/");
+    (method, target)
+}
+
+fn split_query(target: &str) -> (&str, &str) {
+    target.find('?').map_or((target, ""), |i| {
+        let (p, q) = target.split_at(i);
+        let q = q.get(1..).unwrap_or("");
+        (p, q)
+    })
+}
+
+fn parse_since(query: &str) -> u64 {
+    for pair in query.split('&') {
+        if let Some(value) = pair.strip_prefix("since=")
+            && let Ok(n) = value.parse::<u64>()
+        {
+            return n;
+        }
+    }
+    0
+}
+
+fn write_response(
+    stream: &mut TcpStream,
+    code: u16,
+    reason: &str,
+    content_type: &str,
+    body: &[u8],
+) {
+    let header = format!(
+        "HTTP/1.1 {code} {reason}\r\n\
+         Content-Type: {content_type}\r\n\
+         Content-Length: {len}\r\n\
+         Cache-Control: no-store\r\n\
+         Connection: close\r\n\
+         \r\n",
+        len = body.len(),
+    );
+    if let Err(e) = stream.write_all(header.as_bytes()) {
+        log::debug!("observability HTTP write header error: {e}");
+        return;
+    }
+    if let Err(e) = stream.write_all(body) {
+        log::debug!("observability HTTP write body error: {e}");
+        return;
+    }
+    let _ = stream.flush();
+    let _ = stream.shutdown(net::Shutdown::Both);
+}
+
+// --- JSON rendering ---------------------------------------------------------
+
+fn render_info(info: &InfoSnapshot) -> String {
+    let mut out = String::with_capacity(512);
+    out.push('{');
+    field_str(&mut out, "role", info.role, true);
+    field_str(&mut out, "version", info.version, false);
+    field_u64(&mut out, "max_clients", u64::from(info.max_clients), false);
+    field_u64(&mut out, "block_bytes", u64::from(info.block_bytes), false);
+    field_u64(&mut out, "repair_pct", u64::from(info.repair_pct), false);
+    out.push(',');
+    push_key(&mut out, "heartbeat_secs");
+    match info.heartbeat_secs {
+        Some(s) => {
+            let _ = write!(out, "{s}");
+        }
+        None => out.push_str("null"),
+    }
+    field_u64(&mut out, "mtu", u64::from(info.mtu), false);
+    field_opt_string(&mut out, "peer", info.peer.map(|a| a.to_string()), false);
+    field_opt_string(&mut out, "bind", info.bind.map(|a| a.to_string()), false);
+    field_bool(&mut out, "flush", info.flush, false);
+    field_bool(&mut out, "hash", info.hash, false);
+    out.push(',');
+    push_key(&mut out, "listeners");
+    out.push('{');
+    field_opt_string(
+        &mut out,
+        "tcp",
+        info.listener_tcp.map(|a| a.to_string()),
+        true,
+    );
+    field_opt_string(
+        &mut out,
+        "unix",
+        info.listener_unix
+            .as_ref()
+            .map(|p| p.display().to_string()),
+        false,
+    );
+    out.push('}');
+    out.push(',');
+    push_key(&mut out, "forward");
+    out.push('{');
+    field_opt_string(
+        &mut out,
+        "tcp",
+        info.forward_tcp.map(|a| a.to_string()),
+        true,
+    );
+    field_opt_string(
+        &mut out,
+        "unix",
+        info.forward_unix.as_ref().map(|p| p.display().to_string()),
+        false,
+    );
+    out.push('}');
+    out.push('}');
+    out
+}
+
+fn render_status(role: &str, snap: &StatsSnapshot) -> String {
+    let mut out = String::with_capacity(512 + snap.clients.len() * 96);
+    out.push('{');
+    field_str(&mut out, "role", role, true);
+    field_u64(&mut out, "uptime_secs", snap.uptime_secs, false);
+    field_u64(&mut out, "now_unix_ms", snap.now_unix_ms, false);
+    field_u64(&mut out, "bytes_total", snap.bytes_total, false);
+    field_u64(&mut out, "packets_total", snap.packets_total, false);
+    field_u64(&mut out, "transfers_started", snap.transfers_started, false);
+    field_u64(&mut out, "transfers_finished", snap.transfers_finished, false);
+    field_u64(&mut out, "transfers_aborted", snap.transfers_aborted, false);
+    // `active_count` is a `usize`; cast narrowly with `u64::try_from` so we
+    // don't silently wrap on 128-bit-of-the-future targets.
+    field_u64(
+        &mut out,
+        "active_count",
+        u64::try_from(snap.active_count).unwrap_or(u64::MAX),
+        false,
+    );
+    field_u64(
+        &mut out,
+        "last_heartbeat_unix_ms",
+        snap.last_heartbeat_unix_ms,
+        false,
+    );
+    out.push(',');
+    push_key(&mut out, "clients");
+    out.push('[');
+    for (i, c) in snap.clients.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        render_client(&mut out, c);
+    }
+    out.push(']');
+    out.push('}');
+    out
+}
+
+fn render_client(out: &mut String, c: &ClientEntry) {
+    out.push('{');
+    push_key(out, "id");
+    out.push('"');
+    let _ = write!(out, "{:x}", c.id);
+    out.push('"');
+    field_u64(out, "started_unix_ms", c.started_unix_ms, false);
+    field_u64(out, "bytes", c.bytes, false);
+    field_str(out, "state", c.state.as_str(), false);
+    out.push('}');
+}
+
+fn render_logs(ring: Option<&LogRing>, since: u64) -> String {
+    let Some(ring) = ring else {
+        return String::from(r#"{"cursor":0,"lines":[]}"#);
+    };
+    let (cursor, entries) = ring.read_since(since);
+    let mut out = String::with_capacity(128 + entries.len() * 96);
+    out.push('{');
+    push_key(&mut out, "cursor");
+    let _ = write!(out, "{cursor}");
+    out.push(',');
+    push_key(&mut out, "lines");
+    out.push('[');
+    for (i, e) in entries.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('{');
+        push_key(&mut out, "cursor");
+        let _ = write!(out, "{}", e.cursor);
+        field_u64(&mut out, "ts_unix_ms", e.ts_unix_ms, false);
+        field_str(&mut out, "level", e.level, false);
+        field_str(&mut out, "msg", &e.line, false);
+        out.push('}');
+    }
+    out.push(']');
+    out.push('}');
+    out
+}
+
+// --- tiny JSON helpers ------------------------------------------------------
+
+fn push_key(out: &mut String, key: &str) {
+    out.push('"');
+    out.push_str(key);
+    out.push_str("\":");
+}
+
+fn field_str(out: &mut String, key: &str, value: &str, first: bool) {
+    if !first {
+        out.push(',');
+    }
+    push_key(out, key);
+    write_escaped_string(out, value);
+}
+
+fn field_u64(out: &mut String, key: &str, value: u64, first: bool) {
+    if !first {
+        out.push(',');
+    }
+    push_key(out, key);
+    let _ = write!(out, "{value}");
+}
+
+fn field_bool(out: &mut String, key: &str, value: bool, first: bool) {
+    if !first {
+        out.push(',');
+    }
+    push_key(out, key);
+    out.push_str(if value { "true" } else { "false" });
+}
+
+fn field_opt_string(out: &mut String, key: &str, value: Option<String>, first: bool) {
+    if !first {
+        out.push(',');
+    }
+    push_key(out, key);
+    match value {
+        Some(s) => write_escaped_string(out, &s),
+        None => out.push_str("null"),
+    }
+}
+
+fn write_escaped_string(out: &mut String, value: &str) {
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0C}' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
-use std::{fs, path};
+use std::{fs, path, sync::Arc};
 
 pub mod aux;
+pub mod http;
+pub mod logring;
 pub mod protocol;
 pub mod receive;
 pub mod send;
+pub mod stats;
 // Allow unsafe code to call libc function setsockopt.
 #[allow(unsafe_code)]
 mod sock_utils;
@@ -21,6 +24,26 @@ pub fn init_logger(
     file: Option<path::PathBuf>,
     stderr_only: bool,
 ) -> Result<(), String> {
+    init_logger_with_ring(level_filter, file, stderr_only, false).map(|_| ())
+}
+
+/// Logger initializer with optional in-memory ring-buffer tee.
+///
+/// When `with_ring` is true, installs a tee logger that also pushes records
+/// into an in-memory [`logring::LogRing`] returned to the caller so the
+/// observability HTTP server can serve recent log lines. Otherwise behaves
+/// identically to [`init_logger`].
+///
+/// # Errors
+///
+/// Will return `Err` if `file` cannot be opened
+/// or logger cannot be set (Term or file mode).
+pub fn init_logger_with_ring(
+    level_filter: log::LevelFilter,
+    file: Option<path::PathBuf>,
+    stderr_only: bool,
+    with_ring: bool,
+) -> Result<Option<Arc<logring::LogRing>>, String> {
     let terminal_mode = if stderr_only {
         simplelog::TerminalMode::Stderr
     } else {
@@ -37,23 +60,52 @@ pub fn init_logger(
         .unwrap_or_else(|e| e)
         .build();
 
-    match file {
-        Some(file) => fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .truncate(false)
-            .read(false)
-            .open(file)
+    if with_ring {
+        let inner: Box<dyn log::Log> = match file {
+            Some(file) => {
+                let fh = fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .truncate(false)
+                    .read(false)
+                    .open(file)
+                    .map_err(|e| e.to_string())?;
+                simplelog::WriteLogger::new(level_filter, config, fh)
+            }
+            None => simplelog::TermLogger::new(
+                level_filter,
+                config,
+                terminal_mode,
+                simplelog::ColorChoice::Auto,
+            ),
+        };
+        let ring = Arc::new(logring::LogRing::new(1024));
+        let tee = logring::TeeLogger::new(inner, level_filter, Arc::clone(&ring));
+        log::set_boxed_logger(Box::new(tee)).map_err(|e| e.to_string())?;
+        log::set_max_level(level_filter);
+        Ok(Some(ring))
+    } else {
+        match file {
+            Some(file) => fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .truncate(false)
+                .read(false)
+                .open(file)
+                .map_err(|e| e.to_string())
+                .and_then(|file| {
+                    simplelog::WriteLogger::init(level_filter, config, file)
+                        .map_err(|e| e.to_string())
+                })
+                .map(|()| None),
+            None => simplelog::TermLogger::init(
+                level_filter,
+                config,
+                terminal_mode,
+                simplelog::ColorChoice::Auto,
+            )
             .map_err(|e| e.to_string())
-            .and_then(|file| {
-                simplelog::WriteLogger::init(level_filter, config, file).map_err(|e| e.to_string())
-            }),
-        None => simplelog::TermLogger::init(
-            level_filter,
-            config,
-            terminal_mode,
-            simplelog::ColorChoice::Auto,
-        )
-        .map_err(|e| e.to_string()),
+            .map(|()| None),
+        }
     }
 }

--- a/src/logring.rs
+++ b/src/logring.rs
@@ -1,0 +1,111 @@
+//! In-memory bounded log buffer used by the observability HTTP server.
+//!
+//! A [`TeeLogger`] forwards every log record to an existing `log::Log`
+//! implementation (typically the `simplelog` terminal/file logger) and also
+//! pushes a formatted line into a [`LogRing`]. The UI polls `/api/logs?since=`
+//! to read new lines since a monotonic cursor.
+
+use std::{
+    collections::VecDeque,
+    sync::{
+        Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use crate::stats::unix_now_ms;
+
+/// Bounded ring buffer of recent log lines, keyed by a monotonic cursor.
+///
+/// On overflow, the oldest line is dropped so a log call never blocks.
+pub struct LogRing {
+    buffer: Mutex<VecDeque<Entry>>,
+    cap: usize,
+    next_cursor: AtomicU64,
+}
+
+#[derive(Clone)]
+pub struct Entry {
+    pub cursor: u64,
+    pub ts_unix_ms: u64,
+    pub level: &'static str,
+    pub line: String,
+}
+
+impl LogRing {
+    #[must_use]
+    pub fn new(cap: usize) -> Self {
+        Self {
+            buffer: Mutex::new(VecDeque::new()),
+            cap: cap.max(64),
+            next_cursor: AtomicU64::new(1),
+        }
+    }
+
+    pub fn push(&self, level: &'static str, line: String) {
+        let cursor = self.next_cursor.fetch_add(1, Ordering::Relaxed);
+        let entry = Entry {
+            cursor,
+            ts_unix_ms: unix_now_ms(),
+            level,
+            line,
+        };
+        if let Ok(mut guard) = self.buffer.lock() {
+            while guard.len() >= self.cap {
+                guard.pop_front();
+            }
+            guard.push_back(entry);
+        }
+    }
+
+    /// Returns `(new_cursor, entries)` for every entry whose cursor is strictly
+    /// greater than `since`. `new_cursor` is the next value the caller should
+    /// pass back.
+    #[must_use]
+    pub fn read_since(&self, since: u64) -> (u64, Vec<Entry>) {
+        let next = self.next_cursor.load(Ordering::Relaxed);
+        let entries = self.buffer.lock().map_or_else(
+            |_| Vec::new(),
+            |g| g.iter().filter(|e| e.cursor > since).cloned().collect(),
+        );
+        (next, entries)
+    }
+}
+
+/// `log::Log` adapter that tees every record through to `inner` while also
+/// appending to a [`LogRing`].
+pub struct TeeLogger {
+    inner: Box<dyn log::Log>,
+    level: log::LevelFilter,
+    ring: std::sync::Arc<LogRing>,
+}
+
+impl TeeLogger {
+    #[must_use]
+    pub fn new(
+        inner: Box<dyn log::Log>,
+        level: log::LevelFilter,
+        ring: std::sync::Arc<LogRing>,
+    ) -> Self {
+        Self { inner, level, ring }
+    }
+}
+
+impl log::Log for TeeLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        metadata.level() <= self.level
+    }
+
+    fn log(&self, record: &log::Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        self.ring
+            .push(record.level().as_str(), format!("{}", record.args()));
+        self.inner.log(record);
+    }
+
+    fn flush(&self) {
+        self.inner.flush();
+    }
+}

--- a/src/receive/client.rs
+++ b/src/receive/client.rs
@@ -21,6 +21,7 @@ where
     E: Into<receive::Error>,
 {
     log::info!("client {client_id:x}: starting transfer");
+    receiver.stats.client_connected(client_id);
 
     let client = (receiver.client_new)(client_id).map_err(Into::into)?;
     let mut client =
@@ -52,6 +53,7 @@ where
                 hasher.write(payload);
             }
 
+            receiver.stats.add_bytes(client_id, payload.len() as u64);
             transmitted += payload.len();
 
             client.write_all(payload)?;
@@ -63,6 +65,7 @@ where
         match block_type {
             protocol::BlockType::Abort => {
                 log::warn!("client {client_id:x}: aborting transfer");
+                receiver.stats.client_aborted(client_id);
                 (receiver.client_end)(
                     client.into_inner().map_err(|e| {
                         receive::Error::Other(format!("failed to retrieve client inner: {e}",))
@@ -82,6 +85,7 @@ where
                         "client {client_id:x}: finished transfer, {transmitted} bytes transmitted"
                     );
                 }
+                receiver.stats.client_finished(client_id);
                 client.flush()?;
                 (receiver.client_end)(
                     client.into_inner().map_err(|e| {

--- a/src/receive/clients.rs
+++ b/src/receive/clients.rs
@@ -25,6 +25,7 @@ where
 
         if let Err(e) = client_res {
             log::error!("client {client_id:x}: send loop error: {e}");
+            receiver.stats.client_aborted(client_id);
         }
 
         thread::yield_now();

--- a/src/receive/dispatch.rs
+++ b/src/receive/dispatch.rs
@@ -72,6 +72,7 @@ pub fn start<ClientNew, ClientEnd>(
             protocol::BlockType::Heartbeat => {
                 log::debug!("heartbeat received");
                 last_heartbeat = time::Instant::now();
+                receiver.stats.heartbeat_seen();
                 continue;
             }
             protocol::BlockType::Start => {

--- a/src/receive/mod.rs
+++ b/src/receive/mod.rs
@@ -16,7 +16,7 @@
 //! - there are `max_clients` clients workers running in parallel,
 //! - there are `nb_decode_threads` decode workers running in parallel.
 
-use crate::protocol;
+use crate::{protocol, stats::Stats};
 use std::{
     fmt,
     io::{self, Write},
@@ -147,6 +147,7 @@ enum Reassembled {
 pub struct Receiver<ClientNew, ClientEnd> {
     config: Config,
     raptorq: protocol::RaptorQ,
+    pub stats: sync::Arc<Stats>,
     multiplex_control: semka::Sem,
     block_to_dispatch: (sync::Mutex<u8>, sync::Condvar),
     to_reblock: crossbeam_channel::Sender<crate::udp::Datagrams>,
@@ -181,6 +182,7 @@ where
     pub fn new(
         config: Config,
         raptorq: protocol::RaptorQ,
+        stats: sync::Arc<Stats>,
         client_new: ClientNew,
         client_end: ClientEnd,
     ) -> Result<Self, Error> {
@@ -197,6 +199,7 @@ where
         Ok(Self {
             config,
             raptorq,
+            stats,
             multiplex_control,
             block_to_dispatch,
             to_reblock,

--- a/src/receive/udp.rs
+++ b/src/receive/udp.rs
@@ -38,6 +38,11 @@ pub fn start<ClientNew, ClientEnd>(
 
     loop {
         let datagrams = udp.recv()?;
+        let n = match &datagrams {
+            crate::udp::Datagrams::Single(_) => 1,
+            crate::udp::Datagrams::Multiple(v) => v.len() as u64,
+        };
+        receiver.stats.add_packets(n);
         receiver.to_reblock.send(datagrams)?;
     }
 }

--- a/src/send/client.rs
+++ b/src/send/client.rs
@@ -13,6 +13,7 @@ where
     C: io::Read + AsRawFd + Send,
 {
     log::info!("client {client_id:x}: connected");
+    sender.stats.client_connected(client_id);
 
     sender.to_ordering.send(Some(protocol::Block::new(
         protocol::BlockType::Start,
@@ -64,10 +65,12 @@ where
             Some(&buffer[..cursor]),
         )?))?;
 
+        sender.stats.add_bytes(client_id, cursor as u64);
         transmitted += cursor;
         cursor = 0;
 
         if 0 == read {
+            sender.stats.client_finished(client_id);
             if let Some(hasher) = hasher {
                 let hash = hasher.finish_ext();
                 log::info!(

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -19,7 +19,7 @@
 //! - there are `max_clients` clients workers running in parallel,
 //! - there are `nb_encode_threads` encoding workers running in parallel.
 
-use crate::protocol;
+use crate::{protocol, stats::Stats};
 use std::{
     fmt,
     io::{self, Read},
@@ -122,6 +122,7 @@ impl From<protocol::Error> for Error {
 pub struct Sender<C> {
     config: Config,
     raptorq: protocol::RaptorQ,
+    pub stats: sync::Arc<Stats>,
     multiplex_control: semka::Sem,
     block_to_send: (sync::Mutex<u8>, sync::Condvar),
     to_server: crossbeam_channel::Sender<Option<C>>,
@@ -142,7 +143,11 @@ where
     ///
     /// Will return `Err` if `multiplex_control` semaphore
     /// cannot be created.
-    pub fn new(config: Config, raptorq: protocol::RaptorQ) -> Result<Self, Error> {
+    pub fn new(
+        config: Config,
+        raptorq: protocol::RaptorQ,
+        stats: sync::Arc<Stats>,
+    ) -> Result<Self, Error> {
         let multiplex_control = semka::Sem::new(config.max_clients)
             .ok_or(Error::Other("failed to create semaphore".into()))?;
 
@@ -158,6 +163,7 @@ where
         Ok(Self {
             config,
             raptorq,
+            stats,
             multiplex_control,
             block_to_send,
             to_server,

--- a/src/send/server.rs
+++ b/src/send/server.rs
@@ -25,6 +25,7 @@ where
 
         if let Err(e) = client_res {
             log::error!("client {client_id:x}: error: {e}");
+            sender.stats.client_aborted(client_id);
 
             if let Err(e) = sender.to_ordering.send(Some(protocol::Block::new(
                 protocol::BlockType::Abort,

--- a/src/send/udp.rs
+++ b/src/send/udp.rs
@@ -39,7 +39,10 @@ pub fn start<C>(sender: &send::Sender<C>) -> Result<(), send::Error> {
             let mut count = sender.config.nb_encode_threads - 1;
             while 0 < count {
                 match sender.for_send.recv()? {
-                    Some(packets) => udp.send(packets)?,
+                    Some(packets) => {
+                        sender.stats.add_packets(packets.len() as u64);
+                        udp.send(packets)?;
+                    }
                     None => {
                         count -= 1;
                     }
@@ -48,6 +51,7 @@ pub fn start<C>(sender: &send::Sender<C>) -> Result<(), send::Error> {
             return Ok(());
         };
 
+        sender.stats.add_packets(packets.len() as u64);
         udp.send(packets)?;
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,205 @@
+//! Lightweight runtime observability state shared between worker threads and the
+//! optional observability HTTP server.
+//!
+//! Hot-path counters are plain `AtomicU64`/`AtomicUsize` updated with
+//! `Ordering::Relaxed`: we want monotonic increments, not cross-counter ordering.
+//! Per-client entries live under a `Mutex<Vec<...>>` that is only touched on
+//! client connect / finish / abort (the same moments the existing code already
+//! does a log write) and on a snapshot read from the HTTP layer.
+
+use std::{
+    sync::{
+        Mutex,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
+    time::{Instant, SystemTime, UNIX_EPOCH},
+};
+
+use crate::protocol;
+
+pub const ROLE_SEND: &str = "send";
+pub const ROLE_RECEIVE: &str = "receive";
+
+/// Lifecycle state of a transfer, as surfaced to the UI.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ClientState {
+    Connected,
+    Finished,
+    Aborted,
+}
+
+impl ClientState {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Connected => "Connected",
+            Self::Finished => "Finished",
+            Self::Aborted => "Aborted",
+        }
+    }
+}
+
+/// One row in the clients table rendered by the UI.
+#[derive(Clone)]
+pub struct ClientEntry {
+    pub id: protocol::ClientId,
+    pub started_unix_ms: u64,
+    pub bytes: u64,
+    pub state: ClientState,
+}
+
+/// An owned, point-in-time snapshot consumed by the HTTP layer so the lock
+/// doesn't cross any serialization work.
+pub struct StatsSnapshot {
+    pub uptime_secs: u64,
+    pub now_unix_ms: u64,
+    pub bytes_total: u64,
+    pub packets_total: u64,
+    pub transfers_started: u64,
+    pub transfers_finished: u64,
+    pub transfers_aborted: u64,
+    pub active_count: usize,
+    pub last_heartbeat_unix_ms: u64,
+    pub clients: Vec<ClientEntry>,
+}
+
+pub struct Stats {
+    pub role: &'static str,
+    started_at: Instant,
+    bytes_total: AtomicU64,
+    packets_total: AtomicU64,
+    transfers_started: AtomicU64,
+    transfers_finished: AtomicU64,
+    transfers_aborted: AtomicU64,
+    active_count: AtomicUsize,
+    last_heartbeat_unix_ms: AtomicU64,
+    clients: Mutex<Vec<ClientEntry>>,
+    clients_cap: usize,
+}
+
+impl Stats {
+    /// `clients_cap` bounds the number of historical entries retained; on
+    /// overflow the oldest non-active entry is dropped so active transfers are
+    /// always visible.
+    #[must_use]
+    pub fn new(role: &'static str, clients_cap: usize) -> Self {
+        Self {
+            role,
+            started_at: Instant::now(),
+            bytes_total: AtomicU64::new(0),
+            packets_total: AtomicU64::new(0),
+            transfers_started: AtomicU64::new(0),
+            transfers_finished: AtomicU64::new(0),
+            transfers_aborted: AtomicU64::new(0),
+            active_count: AtomicUsize::new(0),
+            last_heartbeat_unix_ms: AtomicU64::new(0),
+            clients: Mutex::new(Vec::new()),
+            clients_cap: clients_cap.max(8),
+        }
+    }
+
+    pub fn client_connected(&self, id: protocol::ClientId) {
+        self.transfers_started.fetch_add(1, Ordering::Relaxed);
+        self.active_count.fetch_add(1, Ordering::Relaxed);
+        let entry = ClientEntry {
+            id,
+            started_unix_ms: unix_now_ms(),
+            bytes: 0,
+            state: ClientState::Connected,
+        };
+        if let Ok(mut guard) = self.clients.lock() {
+            while guard.len() >= self.clients_cap {
+                // Drop the oldest finished/aborted entry; if none, drop the
+                // oldest (shouldn't normally happen since active_count <=
+                // max_clients << clients_cap).
+                let idx = guard
+                    .iter()
+                    .position(|e| e.state != ClientState::Connected)
+                    .unwrap_or(0);
+                guard.remove(idx);
+            }
+            guard.push(entry);
+        }
+    }
+
+    pub fn add_bytes(&self, id: protocol::ClientId, bytes: u64) {
+        self.bytes_total.fetch_add(bytes, Ordering::Relaxed);
+        if let Ok(mut guard) = self.clients.lock() {
+            for entry in guard.iter_mut().rev() {
+                if entry.id == id && entry.state == ClientState::Connected {
+                    entry.bytes = entry.bytes.saturating_add(bytes);
+                    break;
+                }
+            }
+        }
+    }
+
+    pub fn client_finished(&self, id: protocol::ClientId) {
+        self.transfers_finished.fetch_add(1, Ordering::Relaxed);
+        self.dec_active();
+        self.mark_state(id, ClientState::Finished);
+    }
+
+    pub fn client_aborted(&self, id: protocol::ClientId) {
+        self.transfers_aborted.fetch_add(1, Ordering::Relaxed);
+        self.dec_active();
+        self.mark_state(id, ClientState::Aborted);
+    }
+
+    pub fn add_packets(&self, n: u64) {
+        self.packets_total.fetch_add(n, Ordering::Relaxed);
+    }
+
+    pub fn heartbeat_seen(&self) {
+        self.last_heartbeat_unix_ms
+            .store(unix_now_ms(), Ordering::Relaxed);
+    }
+
+    fn dec_active(&self) {
+        let _ = self.active_count.fetch_update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            |v| Some(v.saturating_sub(1)),
+        );
+    }
+
+    fn mark_state(&self, id: protocol::ClientId, state: ClientState) {
+        if let Ok(mut guard) = self.clients.lock() {
+            for entry in guard.iter_mut().rev() {
+                if entry.id == id && entry.state == ClientState::Connected {
+                    entry.state = state;
+                    break;
+                }
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> StatsSnapshot {
+        let clients = self
+            .clients
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default();
+        StatsSnapshot {
+            uptime_secs: self.started_at.elapsed().as_secs(),
+            now_unix_ms: unix_now_ms(),
+            bytes_total: self.bytes_total.load(Ordering::Relaxed),
+            packets_total: self.packets_total.load(Ordering::Relaxed),
+            transfers_started: self.transfers_started.load(Ordering::Relaxed),
+            transfers_finished: self.transfers_finished.load(Ordering::Relaxed),
+            transfers_aborted: self.transfers_aborted.load(Ordering::Relaxed),
+            active_count: self.active_count.load(Ordering::Relaxed),
+            last_heartbeat_unix_ms: self.last_heartbeat_unix_ms.load(Ordering::Relaxed),
+            clients,
+        }
+    }
+}
+
+pub(crate) fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|d| u64::try_from(d.as_millis()).ok())
+        .unwrap_or(0)
+}

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,0 +1,286 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>lidi</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #0f1115;
+    --panel: #161a22;
+    --border: #262c38;
+    --muted: #8892a6;
+    --fg: #e6ebf2;
+    --accent: #7cc5ff;
+    --ok: #5dd39e;
+    --warn: #f5b454;
+    --err: #f06767;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --border: #d9dde5;
+      --muted: #5b6577;
+      --fg: #151a22;
+      --accent: #0c7bd8;
+    }
+  }
+  html, body {
+    background: var(--bg); color: var(--fg);
+    font: 13px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
+    margin: 0; padding: 0;
+  }
+  header {
+    display: flex; align-items: baseline; gap: 12px;
+    padding: 14px 20px; border-bottom: 1px solid var(--border);
+  }
+  header h1 { font-size: 18px; font-weight: 600; margin: 0; }
+  header .role {
+    background: var(--accent); color: #000;
+    padding: 2px 10px; border-radius: 999px;
+    font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  header .version { color: var(--muted); font-size: 12px; }
+  header .peer { color: var(--muted); margin-left: auto; font-family: ui-monospace, monospace; }
+  main {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 16px;
+    padding: 16px 20px; max-width: 1200px; margin: 0 auto;
+  }
+  .panel {
+    background: var(--panel); border: 1px solid var(--border);
+    border-radius: 8px; padding: 12px 14px;
+  }
+  .panel h2 {
+    margin: 0 0 10px; font-size: 11px; font-weight: 600;
+    letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted);
+  }
+  .panel.span { grid-column: 1 / -1; }
+  dl.kv { display: grid; grid-template-columns: max-content 1fr; gap: 4px 16px; margin: 0; }
+  dl.kv dt { color: var(--muted); }
+  dl.kv dd { margin: 0; font-family: ui-monospace, monospace; }
+  .counters { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+  .metric {
+    background: var(--bg); border: 1px solid var(--border);
+    border-radius: 6px; padding: 8px 10px;
+  }
+  .metric .label { color: var(--muted); font-size: 11px; }
+  .metric .value { font-size: 18px; font-family: ui-monospace, monospace; margin-top: 2px; }
+  .pill {
+    display: inline-block; padding: 1px 8px; border-radius: 999px;
+    font-size: 11px; font-weight: 600;
+  }
+  .pill.ok  { background: color-mix(in oklab, var(--ok) 25%, transparent);  color: var(--ok); }
+  .pill.warn{ background: color-mix(in oklab, var(--warn) 25%, transparent); color: var(--warn); }
+  .pill.err { background: color-mix(in oklab, var(--err) 25%, transparent);  color: var(--err); }
+  .pill.mute{ background: color-mix(in oklab, var(--muted) 25%, transparent);color: var(--muted); }
+  table { width: 100%; border-collapse: collapse; font-family: ui-monospace, monospace; }
+  th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--border); font-size: 12px; }
+  th { color: var(--muted); font-weight: 500; }
+  tbody tr:last-child td { border-bottom: 0; }
+  .empty { color: var(--muted); padding: 8px; font-style: italic; }
+  pre.logs {
+    max-height: 320px; overflow: auto; margin: 0;
+    background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+    padding: 8px 10px; font: 12px/1.45 ui-monospace, monospace;
+    white-space: pre-wrap; word-break: break-word;
+  }
+  pre.logs .Error, pre.logs .ERROR { color: var(--err); }
+  pre.logs .Warn,  pre.logs .WARN  { color: var(--warn); }
+  pre.logs .Info,  pre.logs .INFO  { color: var(--fg); }
+  pre.logs .Debug, pre.logs .DEBUG { color: var(--muted); }
+  pre.logs .Trace, pre.logs .TRACE { color: var(--muted); }
+  footer { padding: 10px 20px; color: var(--muted); font-size: 12px; text-align: center; }
+</style>
+</head>
+<body>
+<header>
+  <h1>lidi</h1>
+  <span class="role" id="role">…</span>
+  <span class="version" id="version"></span>
+  <span class="peer" id="peer"></span>
+</header>
+<main>
+  <section class="panel span counters">
+    <div class="metric"><div class="label">Bytes</div>         <div class="value" id="m_bytes">0</div></div>
+    <div class="metric"><div class="label">Packets</div>       <div class="value" id="m_packets">0</div></div>
+    <div class="metric"><div class="label">Active</div>        <div class="value" id="m_active">0</div></div>
+    <div class="metric"><div class="label">Finished / Aborted</div><div class="value" id="m_done">0 / 0</div></div>
+  </section>
+
+  <section class="panel">
+    <h2>Status</h2>
+    <dl class="kv">
+      <dt>Uptime</dt><dd id="s_uptime">–</dd>
+      <dt>Heartbeat</dt><dd id="s_hb">–</dd>
+      <dt>Transfers started</dt><dd id="s_started">0</dd>
+      <dt>Polling</dt><dd id="s_poll"><span class="pill ok">live</span></dd>
+    </dl>
+  </section>
+
+  <section class="panel">
+    <h2>Configuration</h2>
+    <dl class="kv" id="config"></dl>
+  </section>
+
+  <section class="panel span">
+    <h2>Active &amp; recent clients</h2>
+    <table>
+      <thead><tr><th>Client ID</th><th>Started</th><th>Bytes</th><th>Age</th><th>State</th></tr></thead>
+      <tbody id="clients"></tbody>
+    </table>
+  </section>
+
+  <section class="panel span">
+    <h2>Log</h2>
+    <pre class="logs" id="logs"></pre>
+  </section>
+</main>
+<footer>lidi &middot; observability &middot; read-only</footer>
+
+<script>
+(() => {
+  const $ = (id) => document.getElementById(id);
+  let logCursor = 0;
+  let heartbeatSecs = null;
+
+  const fmtBytes = (n) => {
+    if (n < 1024) return n + " B";
+    const units = ["KB","MB","GB","TB","PB"];
+    let v = n / 1024, i = 0;
+    while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+    return v.toFixed(v >= 100 ? 0 : v >= 10 ? 1 : 2) + " " + units[i];
+  };
+
+  const fmtDuration = (ms) => {
+    if (ms < 0) return "–";
+    const s = Math.floor(ms / 1000);
+    if (s < 60) return s + "s";
+    const m = Math.floor(s / 60);
+    if (m < 60) return m + "m " + (s % 60) + "s";
+    const h = Math.floor(m / 60);
+    return h + "h " + (m % 60) + "m";
+  };
+
+  const pillFor = (state) => {
+    if (state === "Connected") return '<span class="pill ok">' + state + '</span>';
+    if (state === "Finished")  return '<span class="pill mute">' + state + '</span>';
+    if (state === "Aborted")   return '<span class="pill err">' + state + '</span>';
+    return state;
+  };
+
+  const fetchJson = (url) =>
+    fetch(url, { cache: "no-store" }).then((r) => {
+      if (!r.ok) throw new Error(r.status + " " + r.statusText);
+      return r.json();
+    });
+
+  const renderConfig = (info) => {
+    $("role").textContent = info.role;
+    $("version").textContent = "v" + info.version;
+    heartbeatSecs = info.heartbeat_secs;
+    document.title = "lidi " + info.role;
+    const peer = info.role === "send"
+      ? (info.peer ? "→ " + info.peer : "")
+      : (info.peer ? "← " + info.peer : "");
+    $("peer").textContent = peer;
+
+    const rows = [];
+    const push = (k, v) => { if (v !== undefined && v !== null && v !== "") rows.push([k, v]); };
+    push("Role", info.role);
+    push("Max clients", info.max_clients);
+    push("Block size", fmtBytes(info.block_bytes));
+    push("Repair", info.repair_pct + "%");
+    push("MTU", info.mtu + " bytes");
+    push("Heartbeat", info.heartbeat_secs != null ? info.heartbeat_secs + "s" : "disabled");
+    if (info.peer)  push(info.role === "send" ? "To (UDP)" : "From (UDP)", info.peer);
+    if (info.bind)  push("UDP bind", info.bind);
+    if (info.listeners && info.listeners.tcp)   push("TCP listener", info.listeners.tcp);
+    if (info.listeners && info.listeners.unix)  push("Unix listener", info.listeners.unix);
+    if (info.forward && info.forward.tcp)       push("Forward TCP", info.forward.tcp);
+    if (info.forward && info.forward.unix)      push("Forward Unix", info.forward.unix);
+    push("Flush", info.flush ? "yes" : "no");
+    push("Hash", info.hash ? "yes" : "no");
+
+    $("config").innerHTML = rows.map(
+      ([k, v]) => "<dt>" + k + "</dt><dd>" + String(v).replace(/[<>&]/g, c => ({
+        "<":"&lt;",">":"&gt;","&":"&amp;"
+      }[c])) + "</dd>"
+    ).join("");
+  };
+
+  const renderStatus = (s) => {
+    $("m_bytes").textContent   = fmtBytes(s.bytes_total);
+    $("m_packets").textContent = s.packets_total.toLocaleString();
+    $("m_active").textContent  = s.active_count;
+    $("m_done").textContent    = s.transfers_finished + " / " + s.transfers_aborted;
+    $("s_uptime").textContent  = fmtDuration(s.uptime_secs * 1000);
+    $("s_started").textContent = s.transfers_started;
+
+    const hb = $("s_hb");
+    if (!s.last_heartbeat_unix_ms) {
+      hb.innerHTML = heartbeatSecs
+        ? '<span class="pill mute">none yet</span>'
+        : '<span class="pill mute">disabled</span>';
+    } else {
+      const age = s.now_unix_ms - s.last_heartbeat_unix_ms;
+      const threshold = (heartbeatSecs || 10) * 1000 * 2;
+      const cls = age > threshold ? "err" : age > (heartbeatSecs || 10) * 1000 ? "warn" : "ok";
+      hb.innerHTML = '<span class="pill ' + cls + '">' + fmtDuration(age) + ' ago</span>';
+    }
+
+    const tbody = $("clients");
+    if (!s.clients.length) {
+      tbody.innerHTML = '<tr><td colspan="5" class="empty">No transfers yet.</td></tr>';
+    } else {
+      // Render newest first.
+      const rows = s.clients.slice().reverse().map((c) => {
+        const age = s.now_unix_ms - c.started_unix_ms;
+        const started = new Date(c.started_unix_ms).toLocaleTimeString();
+        return "<tr><td>" + c.id + "</td><td>" + started + "</td><td>"
+             + fmtBytes(c.bytes) + "</td><td>" + fmtDuration(age) + "</td><td>"
+             + pillFor(c.state) + "</td></tr>";
+      });
+      tbody.innerHTML = rows.join("");
+    }
+  };
+
+  const renderLogs = (payload) => {
+    if (!payload.lines || !payload.lines.length) { logCursor = payload.cursor; return; }
+    const pre = $("logs");
+    const atBottom = pre.scrollHeight - pre.scrollTop - pre.clientHeight < 8;
+    const frag = document.createDocumentFragment();
+    for (const e of payload.lines) {
+      const ts = new Date(e.ts_unix_ms).toISOString().substring(11, 23);
+      const span = document.createElement("span");
+      span.className = e.level;
+      span.textContent = ts + " " + e.level.padEnd(5) + " " + e.msg + "\n";
+      frag.appendChild(span);
+    }
+    pre.appendChild(frag);
+    // Cap DOM size.
+    while (pre.childNodes.length > 2000) pre.removeChild(pre.firstChild);
+    if (atBottom) pre.scrollTop = pre.scrollHeight;
+    logCursor = payload.cursor;
+  };
+
+  const setPoll = (ok) => {
+    $("s_poll").innerHTML = ok
+      ? '<span class="pill ok">live</span>'
+      : '<span class="pill err">disconnected</span>';
+  };
+
+  const tickStatus = () => fetchJson("/api/status").then((s) => { renderStatus(s); setPoll(true); })
+                                                   .catch(() => setPoll(false));
+  const tickLogs   = () => fetchJson("/api/logs?since=" + logCursor).then(renderLogs).catch(() => {});
+
+  fetchJson("/api/info").then(renderConfig).catch(() => setPoll(false));
+  tickStatus();
+  tickLogs();
+  setInterval(tickStatus, 1000);
+  setInterval(tickLogs, 2000);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Each of diode-send and diode-receive can now serve a read-only web UI for operators when --http-addr is passed. The UI shows live config, byte/packet counters, active and recent transfers, heartbeat status, and a tail of recent log records. With no flag, behaviour is unchanged.

No new runtime dependencies:
- std::net::TcpListener + hand-rolled HTTP/1.1 and JSON writer in src/http.rs
- AtomicU64 hot-path counters + cold Mutex client table in src/stats.rs
- In-memory bounded log tee in src/logring.rs
- Single-file HTML+CSS+vanilla-JS UI served via include_str! from src/web/