### PR TITLE
Recursive file transfer + directory watch bug fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +278,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +363,22 @@ dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -410,6 +425,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
 
 [[package]]
 name = "hashbrown"
@@ -616,19 +637,38 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "left-right"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
 
 [[package]]
 name = "libc"
@@ -763,6 +803,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,21 +832,22 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64",
+ "evmap",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -800,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+checksum = "9e56997f084e57b045edf17c3ed8ba7f9f779c670df8206dfd1c736f4c02dc4a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -811,6 +874,7 @@ dependencies = [
  "quanta",
  "rand 0.9.4",
  "rand_xoshiro",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -830,6 +894,15 @@ name = "mock_instant"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-conv"
@@ -869,15 +942,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -895,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -1080,6 +1152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "raptorq"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1233,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1238,6 +1325,15 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1342,6 +1438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -1463,6 +1568,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1526,16 +1661,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1572,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1585,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1595,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1608,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -1651,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/features/send_dir_stability.feature
+++ b/features/send_dir_stability.feature
@@ -2,7 +2,7 @@ Feature: Check lidi-dir-send is still working after a lidi-send restart
 
   Scenario: send-dir is still working after lidi-send restarts
     Given lidi is started with max throughput of 100mbit
-    And lidi-dir-send is started
+    And lidi-dir-send is started with watch
     When we copy a file A of size 10KB
     And lidi-file-receive file A in 5 seconds
     And lidi-send is restarted

--- a/lidi-bindings/src/lib.rs
+++ b/lidi-bindings/src/lib.rs
@@ -32,6 +32,7 @@ pub unsafe extern "C" fn diode_new_config(
         max_files: 0,
         overwrite: false,
         ignore: None,
+        recursive: false,
         watch: false,
         tls: lidi_clients::Tls::default(),
     });
@@ -67,9 +68,11 @@ pub unsafe extern "C" fn diode_send_file(
         return 0;
     }
     let cstr_filepath = unsafe { CStr::from_ptr(ptr_filepath) };
-    let rust_filepath = String::from_utf8_lossy(cstr_filepath.to_bytes()).to_string();
+    let rust_filepath =
+        PathBuf::from(String::from_utf8_lossy(cstr_filepath.to_bytes()).to_string());
 
-    let result: usize = clients::file::send::send_file(config, &rust_filepath).unwrap_or(0);
+    let result: usize =
+        clients::file::send::send_file(config, rust_filepath.as_path(), None).unwrap_or(0);
     u32::try_from(result).unwrap_or(0)
 }
 
@@ -104,6 +107,7 @@ pub unsafe extern "C" fn diode_receive_files(
         max_files: 0,
         overwrite: false,
         ignore: None,
+        recursive: false,
         watch: false,
         tls: config.tls.clone(),
     };

--- a/lidi-clients/src/bin/lidi-dir-send.rs
+++ b/lidi-clients/src/bin/lidi-dir-send.rs
@@ -60,10 +60,12 @@ struct Args {
     tls: lidi_clients::Tls,
     #[clap(long, help = "Regex of file names to ignore")]
     ignore: Option<regex::Regex>,
+    #[clap(long, help = "Recurse in given directory")]
+    recursive: bool,
     #[clap(long, help = "Watch for new files")]
     watch: bool,
     #[clap(help = "Directory containing files to send")]
-    dir: String,
+    dir: path::PathBuf,
 }
 
 fn main() {
@@ -98,12 +100,13 @@ fn main() {
         max_files: args.max_files,
         overwrite: false,
         ignore: args.ignore,
+        recursive: args.recursive,
         #[cfg(feature = "inotify")]
         watch: args.watch,
         tls: args.tls,
     };
 
-    if let Err(e) = lidi_clients::file::send::send_dir(&config, &args.dir) {
+    if let Err(e) = lidi_clients::file::send::send_dir(&config, args.dir.as_path()) {
         log::error!("{e}");
     }
 }

--- a/lidi-clients/src/bin/lidi-file-receive.rs
+++ b/lidi-clients/src/bin/lidi-file-receive.rs
@@ -94,6 +94,7 @@ fn main() {
         max_files: args.max_files,
         overwrite: args.overwrite,
         ignore: None,
+        recursive: false,
         #[cfg(feature = "inotify")]
         watch: false,
         tls: args.tls,

--- a/lidi-clients/src/bin/lidi-file-send.rs
+++ b/lidi-clients/src/bin/lidi-file-send.rs
@@ -52,7 +52,7 @@ struct Args {
     #[clap(flatten)]
     tls: lidi_clients::Tls,
     #[clap(help = "Files to send")]
-    files: Vec<String>,
+    files: Vec<path::PathBuf>,
 }
 
 fn main() {
@@ -87,12 +87,13 @@ fn main() {
         max_files: 0,
         overwrite: false,
         ignore: None,
+        recursive: false,
         #[cfg(feature = "inotify")]
         watch: false,
         tls: args.tls,
     };
 
-    if let Err(e) = lidi_clients::file::send::send_files(&config, &args.files) {
+    if let Err(e) = lidi_clients::file::send::send_files(&config, args.files, None) {
         log::error!("{e}");
     }
 }

--- a/lidi-clients/src/file/mod.rs
+++ b/lidi-clients/src/file/mod.rs
@@ -8,6 +8,7 @@ pub mod protocol;
 pub mod receive;
 pub mod send;
 
+#[allow(clippy::struct_excessive_bools)]
 pub struct Config<D> {
     pub diode: D,
     pub buffer_size: usize,
@@ -16,6 +17,7 @@ pub struct Config<D> {
     pub max_files: usize,
     pub overwrite: bool,
     pub ignore: Option<regex::Regex>,
+    pub recursive: bool,
     #[cfg(feature = "inotify")]
     pub watch: bool,
     pub tls: crate::Tls,

--- a/lidi-clients/src/file/protocol.rs
+++ b/lidi-clients/src/file/protocol.rs
@@ -9,6 +9,8 @@ pub enum Error {
     StringFormatError(FromUtf8Error),
     InvalidFileSize(usize, usize),
     InvalidHash(u128, u128),
+    FilePathTooLong,
+    PathNameTooLong,
 }
 
 impl fmt::Display for Error {
@@ -18,6 +20,8 @@ impl fmt::Display for Error {
             Self::StringFormatError(e) => write!(fmt, "string format error: {e}"),
             Self::InvalidFileSize(s1, s2) => write!(fmt, "invalid file size: {s1} != {s2}"),
             Self::InvalidHash(h1, h2) => write!(fmt, "invalid hash: {h1:x} != {h2:x}"),
+            Self::FilePathTooLong => write!(fmt, "file path too long"),
+            Self::PathNameTooLong => write!(fmt, "path name too long"),
         }
     }
 }
@@ -35,28 +39,48 @@ impl From<FromUtf8Error> for Error {
 }
 
 pub(crate) struct Header {
-    pub(crate) file_name: String,
+    pub(crate) file_path: Vec<String>,
     pub(crate) mode: u32,
     pub(crate) file_length: u64,
 }
 
 impl Header {
     pub(crate) fn serialize_to<W: Write>(&self, w: &mut W) -> Result<(), Error> {
-        w.write_all(&self.file_name.len().to_le_bytes())?;
-        w.write_all(self.file_name.as_bytes())?;
+        let file_path_len =
+            u16::try_from(self.file_path.len()).map_err(|_| Error::FilePathTooLong)?;
+        w.write_all(&file_path_len.to_le_bytes())?;
+
+        for path in &self.file_path {
+            let bytes = path.as_bytes();
+            let path_len = u16::try_from(bytes.len()).map_err(|_| Error::PathNameTooLong)?;
+            w.write_all(&path_len.to_le_bytes())?;
+            w.write_all(bytes)?;
+        }
+
         w.write_all(&self.mode.to_le_bytes())?;
         w.write_all(&self.file_length.to_le_bytes())?;
+
         Ok(())
     }
 
     pub(crate) fn deserialize_from<R: Read>(r: &mut R) -> Result<Self, Error> {
-        let mut file_name_len = [0u8; 8];
-        r.read_exact(&mut file_name_len)?;
-        let file_name_len = usize::from_le_bytes(file_name_len);
+        let mut file_path_len = [0u8; 2];
+        r.read_exact(&mut file_path_len)?;
+        let file_path_len = u16::from_le_bytes(file_path_len);
 
-        let mut file_name = vec![0; file_name_len];
-        r.read_exact(&mut file_name)?;
-        let file_name = String::from_utf8(file_name)?;
+        let mut file_path = Vec::new();
+
+        for _ in 0..file_path_len {
+            let mut path_len = [0u8; 2];
+            r.read_exact(&mut path_len)?;
+            let path_len = u16::from_le_bytes(path_len);
+
+            let mut file_name = vec![0; usize::from(path_len)];
+            r.read_exact(&mut file_name)?;
+            let file_name = String::from_utf8(file_name)?;
+
+            file_path.push(file_name);
+        }
 
         let mut mode = [0u8; 4];
         r.read_exact(&mut mode)?;
@@ -67,7 +91,7 @@ impl Header {
         let file_length = u64::from_le_bytes(file_length);
 
         Ok(Self {
-            file_name,
+            file_path,
             mode,
             file_length,
         })

--- a/lidi-clients/src/file/receive.rs
+++ b/lidi-clients/src/file/receive.rs
@@ -145,11 +145,8 @@ where
 {
     let header = file::protocol::Header::deserialize_from(&mut diode)?;
 
-    let file_path = path::PathBuf::from(header.file_name);
-    let file_name = file_path
-        .file_name()
-        .ok_or_else(|| file::Error::Other(String::from("unwrap of file_name failed")))?;
-    let file_path = output_dir.join(path::PathBuf::from(file_name));
+    let file_path = path::PathBuf::from_iter(&header.file_path);
+    let file_path = output_dir.join(file_path);
 
     log::info!(
         "receiving file {} ({} bytes)",
@@ -162,6 +159,12 @@ where
             "file {} already exists",
             file_path.display()
         )));
+    }
+
+    if let Some(parent) = file_path.parent()
+        && !parent.exists()
+    {
+        fs::create_dir_all(parent)?;
     }
 
     let mut file = fs::OpenOptions::new()

--- a/lidi-clients/src/file/send.rs
+++ b/lidi-clients/src/file/send.rs
@@ -5,26 +5,64 @@ use crate::{file, hash};
 use std::net;
 #[cfg(feature = "unix")]
 use std::os::unix;
+#[cfg(feature = "inotify")]
+use std::{collections, io, thread};
 use std::{
     fs,
     io::{Read, Write},
     os::unix::fs::PermissionsExt,
     path,
 };
-#[cfg(feature = "inotify")]
-use std::{io, thread};
 
 #[cfg(feature = "inotify")]
 fn notifier_thread(
-    dir: &path::Path,
-    to_send: &crossbeam_channel::Sender<path::PathBuf>,
+    dir: path::PathBuf,
+    recursive: bool,
+    to_send: &crossbeam_channel::Sender<Option<path::PathBuf>>,
 ) -> Result<(), file::Error> {
     let mut inotify = inotify::Inotify::init()?;
 
-    inotify.watches().add(
-        dir,
-        inotify::WatchMask::CLOSE_WRITE | inotify::WatchMask::MOVED_TO,
-    )?;
+    let mut watch_mask: inotify::WatchMask =
+        inotify::WatchMask::CLOSE_WRITE | inotify::WatchMask::MOVED_TO;
+    if recursive {
+        watch_mask |= inotify::WatchMask::CREATE;
+    }
+
+    let mut descriptors = collections::HashMap::new();
+
+    let mut todo = collections::HashSet::new();
+    todo.insert(dir);
+
+    loop {
+        if todo.is_empty() {
+            break;
+        }
+
+        let mut next = collections::HashSet::new();
+
+        for dir in todo {
+            log::debug!("watch {}", dir.display());
+            let wd = inotify.watches().add(dir.as_path(), watch_mask)?;
+            descriptors.insert(wd.get_watch_descriptor_id(), dir.clone());
+
+            if recursive {
+                for dir in dir
+                    .read_dir()?
+                    .filter_map(|entry| {
+                        entry
+                            .inspect_err(|e| log::error!("failed to read entry: {e}"))
+                            .ok()
+                            .map(|entry| entry.path())
+                    })
+                    .filter(|path| path.is_dir())
+                {
+                    next.insert(dir);
+                }
+            }
+        }
+
+        todo = next;
+    }
 
     let mut buffer = [0u8; 4096];
 
@@ -32,10 +70,30 @@ fn notifier_thread(
         let events = inotify.read_events_blocking(&mut buffer)?;
         for event in events {
             if let Some(name) = event.name {
-                let path = dir.join(name);
-                to_send.send(path).map_err(|e| {
-                    file::Error::Io(io::Error::new(io::ErrorKind::BrokenPipe, e.to_string()))
-                })?;
+                match descriptors.get(&event.wd.get_watch_descriptor_id()) {
+                    None => {
+                        log::warn!("no descriptor found for event on {}", name.display());
+                    }
+                    Some(dir) => {
+                        let path = dir.join(name);
+                        if path.is_dir() && event.mask.contains(inotify::EventMask::CREATE) {
+                            log::debug!("watch created dir {}", path.display());
+                            let wd = inotify.watches().add(path.clone(), watch_mask)?;
+                            descriptors.insert(wd.get_watch_descriptor_id(), path);
+                        } else if path.is_file()
+                            && (event.mask.contains(inotify::EventMask::CLOSE_WRITE)
+                                || event.mask.contains(inotify::EventMask::MOVED_TO))
+                        {
+                            log::debug!("watch new file {}", path.display());
+                            to_send.send(Some(path)).map_err(|e| {
+                                file::Error::Io(io::Error::new(
+                                    io::ErrorKind::BrokenPipe,
+                                    e.to_string(),
+                                ))
+                            })?;
+                        }
+                    }
+                }
             }
         }
     }
@@ -44,13 +102,12 @@ fn notifier_thread(
 #[cfg(feature = "inotify")]
 fn send_file_thread(
     config: &file::Config<crate::DiodeSend>,
-    for_send: &crossbeam_channel::Receiver<path::PathBuf>,
+    for_send: &crossbeam_channel::Receiver<Option<path::PathBuf>>,
+    base_dir: Option<&path::PathBuf>,
 ) {
     let mut count = 0;
 
     loop {
-        use std::ffi::OsStr;
-
         if config.max_files != 0 && count >= config.max_files {
             break;
         }
@@ -59,32 +116,28 @@ fn send_file_thread(
             break;
         };
 
-        let Some(file_name) = path.file_name().and_then(OsStr::to_str) else {
+        let Some(path) = path else {
+            return;
+        };
+
+        let Some(file_path) = path.as_os_str().to_str() else {
             log::error!("not a file {:?}", path.display());
             continue;
         };
 
         if let Some(ignore) = config.ignore.as_ref()
-            && ignore.is_match(file_name)
+            && ignore.is_match(file_path)
         {
             log::debug!("ignoring {:?}", path.display());
             continue;
         }
 
-        let Ok(path) = path
-            .into_os_string()
-            .into_string()
-            .inspect_err(|e| log::error!("unsupported file name {}", e.display()))
-        else {
-            continue;
-        };
-
-        match send_file(config, &path) {
+        match send_file(config, path.as_path(), base_dir) {
             Ok(total) => {
-                log::info!("file {path:?} sent, {total} bytes sent");
+                log::info!("file {} sent, {total} bytes sent", path.display());
             }
             Err(e) => {
-                log::error!("failed to send file {path}: {e}");
+                log::error!("failed to send file {}: {e}", path.display());
             }
         }
 
@@ -92,38 +145,77 @@ fn send_file_thread(
     }
 }
 
-pub fn send_dir(config: &file::Config<crate::DiodeSend>, path: &String) -> Result<(), file::Error> {
+pub fn send_dir(
+    config: &file::Config<crate::DiodeSend>,
+    path: &path::Path,
+) -> Result<(), file::Error> {
     let dir = path::PathBuf::from(path);
 
     if !dir.is_dir() {
-        return Err(file::Error::Other(format!("{path:?} is not a directory")));
+        return Err(file::Error::Other(format!(
+            "{} is not a directory",
+            path.display()
+        )));
     }
 
     let (to_send, for_send) = crossbeam_channel::unbounded();
 
     thread::scope(|scope| {
-        thread::Builder::new().spawn_scoped(scope, || send_file_thread(config, &for_send))?;
-
-        #[cfg(feature = "inotify")]
-        thread::Builder::new().spawn_scoped(scope, || {
-            if let Err(e) = notifier_thread(&dir, &to_send) {
-                log::error!("{e}");
-            }
+        let ldir = dir.clone();
+        thread::Builder::new().spawn_scoped(scope, move || {
+            send_file_thread(config, &for_send, Some(&ldir));
         })?;
 
-        for file in dir
-            .read_dir()?
-            .filter_map(|entry| {
-                entry
-                    .inspect_err(|e| log::error!("failed to read entry: {e}"))
-                    .ok()
-                    .map(|entry| entry.path())
-            })
-            .filter(|path| path.is_file())
-        {
-            if to_send.send(file).is_err() {
+        if config.watch {
+            #[cfg(not(feature = "inotify"))]
+            log::warn!("cannot watch directory because inotify was not enabled at compilation");
+            #[cfg(feature = "inotify")]
+            {
+                let dir = dir.clone();
+                thread::Builder::new().spawn_scoped(scope, || {
+                    if let Err(e) = notifier_thread(dir, config.recursive, &to_send) {
+                        log::error!("{e}");
+                    }
+                })?;
+            }
+        }
+
+        let mut todo = collections::HashSet::new();
+        todo.insert(dir);
+
+        'outer: loop {
+            if todo.is_empty() {
                 break;
             }
+
+            let mut next = collections::HashSet::new();
+
+            for dir in todo {
+                for entry in dir
+                    .read_dir()?
+                    .filter_map(|entry| {
+                        entry
+                            .inspect_err(|e| log::error!("failed to read entry: {e}"))
+                            .ok()
+                            .map(|entry| entry.path())
+                    })
+                    .filter(|entry| config.recursive || entry.is_file())
+                {
+                    if entry.is_dir() {
+                        next.insert(entry);
+                    } else if entry.is_file() && to_send.send(Some(entry)).is_err() {
+                        break 'outer;
+                    }
+                }
+            }
+
+            todo = next;
+        }
+
+        if !config.watch {
+            to_send
+                .send(None)
+                .map_err(|_| file::Error::Other(String::from("failed to stop sender thread")))?;
         }
 
         Ok(())
@@ -136,11 +228,12 @@ pub fn send_dir(config: &file::Config<crate::DiodeSend>, path: &String) -> Resul
 /// returns an `Err`.
 pub fn send_files(
     config: &file::Config<crate::DiodeSend>,
-    paths: &[String],
+    paths: Vec<path::PathBuf>,
+    base_dir: Option<&path::PathBuf>,
 ) -> Result<(), file::Error> {
     for path in paths {
-        let total = send_file(config, path)?;
-        log::info!("file {path:?} sent, {total} bytes sent");
+        let total = send_file(config, path.as_path(), base_dir)?;
+        log::info!("file {} sent, {total} bytes sent", path.display());
     }
     Ok(())
 }
@@ -154,7 +247,8 @@ pub fn send_files(
 ///   fails.
 pub fn send_file(
     config: &file::Config<crate::DiodeSend>,
-    path: &String,
+    path: &path::Path,
+    base_dir: Option<&path::PathBuf>,
 ) -> Result<usize, file::Error> {
     log::debug!("connecting to {}", config.diode);
 
@@ -169,7 +263,7 @@ pub fn send_file(
             #[cfg(feature = "tcp")]
             {
                 let diode = net::TcpStream::connect(socket_addr)?;
-                send_file_aux(config, diode, &path::PathBuf::from(path))
+                send_file_aux(config, diode, path, base_dir)
             }
         }
         crate::DiodeSend::Tls(socket_addr) => {
@@ -183,7 +277,7 @@ pub fn send_file(
             {
                 let context = tls::ClientContext::try_from(&config.tls)?;
                 let diode = tls::TcpStream::connect(&context, socket_addr)?;
-                send_file_aux(config, diode, &path::PathBuf::from(path))
+                send_file_aux(config, diode, path, base_dir)
             }
         }
         crate::DiodeSend::Unix(spath) => {
@@ -196,7 +290,7 @@ pub fn send_file(
             #[cfg(feature = "unix")]
             {
                 let diode = unix::net::UnixStream::connect(spath)?;
-                send_file_aux(config, diode, &path::PathBuf::from(path))
+                send_file_aux(config, diode, path, base_dir)
             }
         }
     }
@@ -205,7 +299,8 @@ pub fn send_file(
 fn send_file_aux<D>(
     config: &file::Config<crate::DiodeSend>,
     mut diode: D,
-    file_path: &path::PathBuf,
+    file_path: &path::Path,
+    base_dir: Option<&path::PathBuf>,
 ) -> Result<usize, file::Error>
 where
     D: Read + Write,
@@ -222,22 +317,39 @@ where
         .create(false)
         .open(file_path)?;
 
-    let file_name = file_path
-        .file_name()
-        .ok_or_else(|| file::Error::Other(String::from("unwrap of file_name failed")))?
-        .to_os_string()
-        .into_string()
-        .map_err(|_| {
-            file::Error::Other(String::from("conversion from OsString to String failed"))
-        })?;
-
-    log::debug!("file name is {file_name:?}");
-
     let metadata = file.metadata()?;
     let permissions = metadata.permissions();
 
+    let file_path = if let Some(base_dir) = base_dir {
+        let mut paths = vec![];
+        let file_path = file_path.strip_prefix(base_dir).map_err(|_| {
+            file::Error::Other(format!(
+                "file {} is not in {}",
+                file_path.display(),
+                base_dir.display()
+            ))
+        })?;
+        for path in file_path.components() {
+            paths.push(path.as_os_str().to_os_string().into_string().map_err(|_| {
+                file::Error::Other(String::from("conversion from OsString to String failed"))
+            })?);
+        }
+        paths
+    } else {
+        vec![
+            file_path
+                .file_name()
+                .ok_or_else(|| file::Error::Other(String::from("unwrap of file_name failed")))?
+                .to_os_string()
+                .into_string()
+                .map_err(|_| {
+                    file::Error::Other(String::from("conversion from OsString to String failed"))
+                })?,
+        ]
+    };
+
     let header = file::protocol::Header {
-        file_name,
+        file_path,
         mode: permissions.mode(),
         file_length: metadata.len(),
     };
@@ -256,8 +368,8 @@ where
     };
 
     log::info!(
-        "sending file {} ({} bytes)",
-        file_path.display(),
+        "sending file {:?} ({} bytes)",
+        header.file_path,
         header.file_length
     );
 

--- a/lidi-clients/src/file/send.rs
+++ b/lidi-clients/src/file/send.rs
@@ -120,13 +120,9 @@ fn send_file_thread(
             return;
         };
 
-        let Some(file_path) = path.as_os_str().to_str() else {
-            log::error!("not a file {:?}", path.display());
-            continue;
-        };
-
         if let Some(ignore) = config.ignore.as_ref()
-            && ignore.is_match(file_path)
+            && let Some(file_name) = path.file_name().and_then(|s| s.to_str())
+            && ignore.is_match(file_name)
         {
             log::debug!("ignoring {:?}", path.display());
             continue;

--- a/lidi-clients/src/file/send.rs
+++ b/lidi-clients/src/file/send.rs
@@ -15,21 +15,15 @@ use std::{
 };
 
 #[cfg(feature = "inotify")]
-fn notifier_thread(
+fn notifier_new_dir(
     dir: path::PathBuf,
-    recursive: bool,
+    inotify: &inotify::Inotify,
+    watch_mask: inotify::WatchMask,
+    descriptors: &mut collections::HashMap<i32, path::PathBuf>,
     to_send: &crossbeam_channel::Sender<Option<path::PathBuf>>,
+    recursive: bool,
+    send_files: bool,
 ) -> Result<(), file::Error> {
-    let mut inotify = inotify::Inotify::init()?;
-
-    let mut watch_mask: inotify::WatchMask =
-        inotify::WatchMask::CLOSE_WRITE | inotify::WatchMask::MOVED_TO;
-    if recursive {
-        watch_mask |= inotify::WatchMask::CREATE;
-    }
-
-    let mut descriptors = collections::HashMap::new();
-
     let mut todo = collections::HashSet::new();
     todo.insert(dir);
 
@@ -46,23 +40,57 @@ fn notifier_thread(
             descriptors.insert(wd.get_watch_descriptor_id(), dir.clone());
 
             if recursive {
-                for dir in dir
-                    .read_dir()?
-                    .filter_map(|entry| {
-                        entry
-                            .inspect_err(|e| log::error!("failed to read entry: {e}"))
-                            .ok()
-                            .map(|entry| entry.path())
-                    })
-                    .filter(|path| path.is_dir())
-                {
-                    next.insert(dir);
+                for path in dir.read_dir()?.filter_map(|entry| {
+                    entry
+                        .inspect_err(|e| log::error!("failed to read entry: {e}"))
+                        .ok()
+                        .map(|entry| entry.path())
+                }) {
+                    if path.is_dir() {
+                        next.insert(path);
+                    } else if send_files && path.is_file() {
+                        to_send.send(Some(path)).map_err(|e| {
+                            file::Error::Io(io::Error::new(
+                                io::ErrorKind::BrokenPipe,
+                                e.to_string(),
+                            ))
+                        })?;
+                    }
                 }
             }
         }
 
         todo = next;
     }
+
+    Ok(())
+}
+
+#[cfg(feature = "inotify")]
+fn notifier_thread(
+    dir: path::PathBuf,
+    recursive: bool,
+    to_send: &crossbeam_channel::Sender<Option<path::PathBuf>>,
+) -> Result<(), file::Error> {
+    let mut inotify = inotify::Inotify::init()?;
+
+    let mut watch_mask: inotify::WatchMask =
+        inotify::WatchMask::CLOSE_WRITE | inotify::WatchMask::MOVED_TO;
+    if recursive {
+        watch_mask |= inotify::WatchMask::CREATE;
+    }
+
+    let mut descriptors = collections::HashMap::new();
+
+    notifier_new_dir(
+        dir,
+        &inotify,
+        watch_mask,
+        &mut descriptors,
+        to_send,
+        recursive,
+        false,
+    )?;
 
     let mut buffer = [0u8; 4096];
 
@@ -76,10 +104,17 @@ fn notifier_thread(
                     }
                     Some(dir) => {
                         let path = dir.join(name);
-                        if path.is_dir() && event.mask.contains(inotify::EventMask::CREATE) {
+                        if path.is_dir() {
                             log::debug!("watch created dir {}", path.display());
-                            let wd = inotify.watches().add(path.clone(), watch_mask)?;
-                            descriptors.insert(wd.get_watch_descriptor_id(), path);
+                            notifier_new_dir(
+                                path,
+                                &inotify,
+                                watch_mask,
+                                &mut descriptors,
+                                to_send,
+                                recursive,
+                                true,
+                            )?;
                         } else if path.is_file()
                             && (event.mask.contains(inotify::EventMask::CLOSE_WRITE)
                                 || event.mask.contains(inotify::EventMask::MOVED_TO))


### PR DESCRIPTION
- Fix bug where `--watch` was honored by default in `lidi-dir-send` 
- Recursive file transfer by `lidi-dir-send` and `lidi-file-receive`
- Update  dependencies