### PR TITLE
Reduce test duration and fix tls and abort message

### DIFF
--- a/doc/udp.rst
+++ b/doc/udp.rst
@@ -1,35 +1,110 @@
 Sending UDP with Lidi
 =====================
 
+``lidi-udp-send`` and ``lidi-udp-receive`` form a tunnel that forwards UDP
+datagrams through the lidi diode.  Each datagram is encapsulated with an
+8-byte size header on the TCP stream so that the receiver can reconstruct
+exact datagram boundaries.
+
 .. code-block:: none
 
-   Send UDP datagrams to diode-receive-udp.
+   Send UDP datagrams to lidi-udp-receive.
 
-   Usage: diode-send-udp [OPTIONS] --from <ip:port> <--to-tcp <ip:port>|--to-unix <path>>
+   Usage: lidi-udp-send [OPTIONS] --from <ip:port> <--to-tcp <ip:port>|--to-unix <path>>
 
    Options:
          --log-level <Off|Error|Warn|Info|Debug|Trace>  Log level [default: Info]
-         --to-tcp <ip:port>                             TCP address and port to connect to diode-send
-         --to-unix <path>                               Path to Unix socket to connect to diode-send
+         --to-tcp <ip:port>                             TCP address and port to connect to lidi-send
+         --to-unix <path>                               Path to Unix socket to connect to lidi-send
          --from <ip:port>                               IP address and port to receive UDP packets
      -h, --help                                         Print help
 
 .. code-block:: none
 
-   Receive UDP packets sent by diode-send-udp.
+   Receive UDP packets sent by lidi-udp-send.
 
-   Usage: diode-receive-udp [OPTIONS] --to-bind <ip:port> --to <ip:port> <--from-tcp <ip:port>|--from-unix <path>>
+   Usage: lidi-udp-receive [OPTIONS] --to-bind <ip:port> --to <ip:port> <--from-tcp <ip:port>|--from-unix <path>>
 
    Options:
          --log-level <Off|Error|Warn|Info|Debug|Trace>
              Log level [default: Info]
          --from-tcp <ip:port>
-             IP address and port to accept TCP connections from diode-receive
+             IP address and port to accept TCP connections from lidi-receive
          --from-unix <path>
-             Path of Unix socket to accept Unix connections from diode-receive
+             Path of Unix socket to accept Unix connections from lidi-receive
          --to-bind <ip:port>
              IP address and port to send UDP packets from
          --to <ip:port>
              IP address and port to send UDP packets to
      -h, --help
-             Print help   
+             Print help
+
+Required ``flush=true`` configuration
+--------------------------------------
+
+Unlike file or stream transfers, the UDP tunnel keeps both TCP connections
+open for the entire lifetime of the session — ``lidi-udp-send`` never closes
+its connection to ``lidi-send``, and ``lidi-receive`` never closes its
+connection to ``lidi-udp-receive``.  This means lidi never receives an EOF
+that would normally trigger flushing of pending data.  Without explicit
+``flush=true`` on both endpoints, datagrams accumulate silently and are never
+forwarded.
+
+**lidi-send ``from`` endpoint — mandatory ``flush=true``**
+
+``lidi-send`` fills a RaptorQ block (``block`` bytes, default 220 000) before
+encoding and sending it.  If datagrams are smaller than ``block``, the block
+is never full and no data is ever sent.  Setting ``flush=true`` tells
+``lidi-send`` to encode and send a block after every ``read()`` call,
+regardless of how full it is:
+
+.. code-block:: toml
+
+   # lidi-send configuration
+   [send]
+   from = [ "tcp[flush=true]:127.0.0.1:4000" ]
+
+**lidi-receive ``to`` endpoint — mandatory ``flush=true``**
+
+``lidi-receive`` writes decoded data to ``lidi-udp-receive`` through a
+buffered writer.  Without ``flush=true``, the buffer is only flushed when an
+``End`` block arrives (i.e. when the sender closes the connection), which
+never happens with the UDP tunnel.  Setting ``flush=true`` forces a flush
+after each write:
+
+.. code-block:: toml
+
+   # lidi-receive configuration
+   [receive]
+   to = [ "tcp[flush=true]:127.0.0.1:6000" ]
+
+Minimal example configuration
+------------------------------
+
+.. code-block:: toml
+
+   # lidi-send.toml
+   ports = [5000]
+
+   [send]
+   from = [ "tcp[flush=true]:127.0.0.1:4000" ]   # lidi-udp-send connects here
+   to   = "192.168.1.2"
+
+.. code-block:: toml
+
+   # lidi-receive.toml
+   ports = [5000]
+
+   [receive]
+   from = "0.0.0.0"
+   to   = [ "tcp[flush=true]:127.0.0.1:6000" ]   # lidi-udp-receive listens here
+
+Start the components in this order:
+
+.. code-block:: bash
+
+   lidi-receive --config lidi-receive.toml &
+   lidi-send    --config lidi-send.toml    &
+
+   lidi-udp-receive --from-tcp 127.0.0.1:6000 --to-bind 127.0.0.1:0 --to 127.0.0.1:7000 &
+   lidi-udp-send    --to-tcp   127.0.0.1:4000 --from 127.0.0.1:5010

--- a/features/bandwidth.feature
+++ b/features/bandwidth.feature
@@ -5,24 +5,28 @@
 #
 Feature: Send simple files with limited network bandwidth
 
-  Scenario: Send 100MB file with max network of 100 Mb/s
+  Scenario: Send 10MB file with max network of 100 Mb/s
+    # Network simulator drops packets above 100Mb/s; lidi runs at 95mbit so the
+    # cap is never hit. 10MB at ~12MB/s takes <1s, well within the 5s grace.
     Given there is a limited network bandwidth of 100 Mb/s
     And lidi is started with max throughput of 95mbit
-    When lidi-file-send file A of size 100MB
+    When lidi-file-send file A of size 10MB
     Then lidi-file-receive file A in 5 seconds
 
-  Scenario: Send multiple 100MB file with max network of 100 Mb/s, 3 files received
+  Scenario: Send multiple 10MB file with max network of 100 Mb/s, 3 files received
     Given there is a limited network bandwidth of 100 Mb/s
     And lidi is started with max throughput of 95mbit
-    When lidi-file-send file A of size 100MB
-    And lidi-file-send file B of size 100MB
-    And lidi-file-send file C of size 100MB
+    When lidi-file-send file A of size 10MB
+    And lidi-file-send file B of size 10MB
+    And lidi-file-send file C of size 10MB
     Then lidi-file-receive file A in 5 seconds
     And lidi-file-receive file B in 5 seconds
     And lidi-file-receive file C in 5 seconds
 
   Scenario: Ensure bandwidth is never exceeded
-    Given network bandwidth must not exceed 1 Mb/s 
+    # tc shaper enforces 990kbit at the packet level regardless of file size;
+    # 500KB (~4s of data) gives the network simulator a stable measurement window.
+    Given network bandwidth must not exceed 1 Mb/s
     And lidi is started with max throughput of 990kbit
-    When lidi-file-send file A of size 3MB
-    Then lidi-file-receive file A in 30 seconds
+    When lidi-file-send file A of size 500KB
+    Then lidi-file-receive file A in 10 seconds

--- a/features/basics.feature
+++ b/features/basics.feature
@@ -24,7 +24,8 @@ Feature: Basic lidi functionality
     Then lidi-file-receive file C in 5 seconds
 
   Scenario: Send multiple 100M files without drop
-    Given lidi is started with max throughput of 100mbit
+    # 3×100MB at 400mbit (50MB/s): ~6s transfer, well within 5s per-file grace.
+    Given lidi is started with max throughput of 400mbit
     When lidi-file-send file A of size 100MB
     When lidi-file-send file B of size 100MB
     When lidi-file-send file C of size 100MB

--- a/features/buffer_size.feature
+++ b/features/buffer_size.feature
@@ -6,7 +6,7 @@
 Feature: Test --buffer-size option with various values
 
   Scenario Outline: Send file with different buffer sizes
-    Given lidi is started
+    Given lidi is started with max throughput of 100mbit
     And buffer size is set to <buffer_size>
     When lidi-file-send file test.bin of size 1MB
     Then lidi-file-receive file test.bin in 10 seconds

--- a/features/drop.feature
+++ b/features/drop.feature
@@ -17,11 +17,12 @@ Feature: Send simple files with network drop
     When lidi-file-send file A of size 100KB
     Then lidi-file-receive file A in 5 seconds
 
-  Scenario: Send a 100M file with drop
+  Scenario: Send a 10M file with drop
+    # 10MB at 100mbit (12.5MB/s): ~0.8s transfer; enough blocks to exercise repair.
     Given there is a network drop of 5 %
     And repair percentage is 5 %
     And lidi is started with max throughput of 100mbit
-    When lidi-file-send file A of size 100MB 
+    When lidi-file-send file A of size 10MB
     Then lidi-file-receive file A in 5 seconds
 
   Scenario: Send a 10M file with high drop
@@ -36,5 +37,5 @@ Feature: Send simple files with network drop
     And repair percentage is 10 %
     And lidi is started with max throughput of 100mbit
     When lidi-file-send file A of size 100KB
-    Then wait 10 seconds
+    Then wait 3 seconds
     And the receiver Prometheus counter lidi_receive_blocks_decode_failed is greater than or equal to 1

--- a/features/environment.py
+++ b/features/environment.py
@@ -5,9 +5,11 @@ import signal
 import subprocess
 import time
 import os
+from pathlib import Path
 
 from features.steps.lidi import stop_throttled_diode
 from features.steps.utils import kill_process_safe
+from features.steps.tls_pki import generate_pki
 
 # function called before any feature or scenario
 def before_all(context):
@@ -65,6 +67,13 @@ def before_scenario(context, _feature):
     os.makedirs(context.send_dir, exist_ok=True)
     os.makedirs(context.receive_dir, exist_ok=True)
     os.makedirs(context.log_dir, exist_ok=True)
+
+    # Generate test PKI for TLS tests
+    context.pki_dir = Path(context.base_dir) / 'pki'
+    try:
+        generate_pki(context.pki_dir)
+    except Exception as e:
+        print(f"Warning: Failed to generate PKI: {e}")
 
     # files metadata
     context.files = {}

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,15 +1,35 @@
 # functions to be called before or after tests must be put here
 
-from tempfile import TemporaryDirectory
 import signal
 import subprocess
 import time
 import os
 from pathlib import Path
+import psutil
 
 from features.steps.lidi import stop_throttled_diode
 from features.steps.utils import kill_process_safe
 from features.steps.tls_pki import generate_pki
+
+_LIDI_PROCESS_NAMES = {
+    'lidi-send', 'lidi-receive', 'lidi-file-send', 'lidi-file-receive',
+    'lidi-dir-send', 'lidi-network-simulator',
+}
+
+def wait_for_processes_dead(max_wait=1.0):
+    """Return as soon as no lidi processes remain, up to max_wait seconds."""
+    deadline = time.monotonic() + max_wait
+    while time.monotonic() < deadline:
+        try:
+            if not any(p.info['name'] in _LIDI_PROCESS_NAMES
+                       for p in psutil.process_iter(['name'])):
+                return True
+        except psutil.Error:
+            pass
+        time.sleep(0.02)
+    os.system("pkill -9 -f lidi 2>/dev/null")
+    return False
+
 
 # function called before any feature or scenario
 def before_all(context):
@@ -173,8 +193,8 @@ def after_scenario(context, _scenario):
     kill_process_safe('proc_network', 'lidi-network-simulator', context)
     kill_process_safe('proc_lidi_receive_file', 'lidi-file-receive', context)
 
-    # make sure everything is killed, even throttled_fs (fuse) which uses temp directories
-    time.sleep(1)
+    # Wait until all lidi processes are dead before starting the next scenario
+    wait_for_processes_dead()
 
     # Clear files metadata
     context.files.clear()

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,6 +1,7 @@
 # functions to be called before or after tests must be put here
 
 from tempfile import TemporaryDirectory
+import signal
 import subprocess
 import time
 import os
@@ -111,12 +112,32 @@ def before_scenario(context, _feature):
     context.log_config_network_behavior = None
 
     context.lidi_config_path = context.base_dir
-    
+
+    # file_receive scenario state
+    context._file_receive_suspended = False
+    context._receive_dir_was_readonly = False
+
     # setup logging configuration
     setup_log_config(context, context.log_dir)
 
 # function called after every test : cleanup (delete temp directories & kill processes)
 def after_scenario(context, _scenario):
+    # Resume a SIGSTOPped lidi-file-receive so SIGKILL is delivered cleanly.
+    # SIGKILL works on stopped processes too, but SIGCONT first avoids any edge cases.
+    proc_frc = getattr(context, 'proc_lidi_receive_file', None)
+    if proc_frc and proc_frc.poll() is None and context._file_receive_suspended:
+        try:
+            os.kill(proc_frc.pid, signal.SIGCONT)
+        except (ProcessLookupError, OSError):
+            pass
+
+    # Restore receive_dir permissions so shutil.rmtree can clean it up.
+    if context._receive_dir_was_readonly:
+        try:
+            os.chmod(context.receive_dir, 0o755)
+        except OSError:
+            pass
+
     stop_throttled_diode(context)
 
     # Kill concurrent processes from multi-client tests

--- a/features/environment.py
+++ b/features/environment.py
@@ -68,6 +68,9 @@ def before_scenario(context, _feature):
     # files metadata
     context.files = {}
 
+    # concurrent processes for multi-client tests
+    context.concurrent_processes = []
+
     # process instances
     context.proc_lidi_receive = None
     context.proc_lidi_send = None
@@ -115,7 +118,23 @@ def before_scenario(context, _feature):
 # function called after every test : cleanup (delete temp directories & kill processes)
 def after_scenario(context, _scenario):
     stop_throttled_diode(context)
-    
+
+    # Kill concurrent processes from multi-client tests
+    if hasattr(context, 'concurrent_processes'):
+        for proc_info in context.concurrent_processes:
+            proc = proc_info.get('process')
+            if proc and proc.poll() is None:
+                try:
+                    proc.terminate()
+                    proc.wait(timeout=5)
+                except (subprocess.TimeoutExpired, ProcessLookupError):
+                    try:
+                        proc.kill()
+                        proc.wait(timeout=2)
+                    except (subprocess.TimeoutExpired, ProcessLookupError):
+                        pass
+        context.concurrent_processes.clear()
+
     # first kill processes
     kill_process_safe('proc_lidi_receive', 'lidi-receive', context)
     kill_process_safe('proc_lidi_send', 'lidi-send', context)

--- a/features/file_receive.feature
+++ b/features/file_receive.feature
@@ -53,29 +53,67 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
   # Group B — lidi-file-receive failure during reception
   # ---------------------------------------------------------------------------
 
-  @wip
-  Scenario: T-FRC-B1 — kill lidi-file-receive mid-transfer: broken pipe, lidi-receive survives
+  Scenario: T-FRC-B1 — kill lidi-file-receive mid-transfer: broken pipe leaves a partial file on disk
     # Killing lidi-file-receive closes the TCP socket. The next write_all() in lidi-receive
     # returns EPIPE. The client worker exits, the pre-allocated thread loops back to
-    # for_clients.recv() and is ready for the next transfer.
-    # lidi-receive stays running (passes). The file assertion fails due to a known Rust defect:
+    # for_clients.recv() and is ready for the next transfer. lidi-receive stays running.
     #
     # Root cause (lidi-clients/src/file/receive.rs):
-    #   receive_file() opens the output file with OpenOptions::create(true) as soon as the
-    #   header is received. When lidi-file-receive is killed (SIGKILL), the OS closes the
-    #   TCP socket; receive_file() returns Err(InvalidFileSize) but never calls
-    #   fs::remove_file(). A partial (possibly 0-byte) output file remains on disk.
-    # Fix: call fs::remove_file(&file_path) in the error path of receive_file().
-    # See also: file_receive_partial_cleanup.feature (T-FRC1).
+    #   Without --use-tmp-file, receive_file() opens the final output file directly with
+    #   OpenOptions::create(true).truncate(true) as soon as the header is received. When
+    #   lidi-file-receive is killed (SIGKILL), the OS closes the TCP socket;
+    #   receive_file() returns Err(InvalidFileSize) and the partial (possibly 0-byte)
+    #   output file is left in place under its final name.
+    # Fix: use --use-tmp-file to write atomically via a temporary file. See T-FRC-B1-FIXED.
     Given lidi is started with max_clients set to 1 and limited to 800kbit
     When client 1 starts sending "input_1m" of size 1MB
     And lidi-file-receive is killed after 2 seconds
     And 5 seconds are waited for slot release
     Then lidi-receive should still be running
-    # Fails: partial "input_1m" is left on disk (partial file cleanup defect)
+    # Demonstrates the defect: a partial "input_1m" is left under its final name
+    And file "input_1m" of size 1MB should remain on disk as an incomplete file
+
+  Scenario: T-FRC-B1-FIXED — kill lidi-file-receive mid-transfer with --use-tmp-file (atomic write)
+    # Same as T-FRC-B1 but with --use-tmp-file enabled. Content is written to a uniquely
+    # named temporary file (via tempfile::NamedTempFile) and persisted atomically on
+    # success. If the process is killed mid-transfer, "input_1m" never exists in a
+    # partial state — only the orphaned .tmp file remains (cleaned up automatically on
+    # the next lidi-file-receive startup), which is harmless.
+    Given lidi-file-receive uses atomic tmp file writes
+    And lidi is started with max_clients set to 1 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 1MB
+    And lidi-file-receive is killed after 2 seconds
+    And 5 seconds are waited for slot release
+    Then lidi-receive should still be running
     And file "input_1m" should not be received
 
-  @wip
+  Scenario: T-FRC-B2 — sender stopped mid-transfer: partial file must be removed
+    # Tests the scenario where the sender (lidi-send) stops mid-transfer, not the
+    # receiver. Unlike killing lidi-file-receive (SIGKILL), stopping lidi-send allows
+    # the transfer to fail gracefully on the receiver side.
+    #
+    # Mechanism:
+    #   1. lidi-file-send sends to lidi-send over loopback TCP (no rate limit)
+    #   2. lidi-send buffers the entire file in milliseconds
+    #   3. Stopping lidi-send stops UDP transmission
+    #   4. After reset_timeout (2s), lidi-receive's block channel closes
+    #   5. Worker exits → TCP to lidi-file-receive closes → diode.read() returns 0
+    #   6. receive_file() returns Err(InvalidFileSize) with remaining > 0
+    #
+    # Root cause fix (commit 433ae0d):
+    #   receive_file() wraps write_file_content() in a match statement and calls
+    #   fs::remove_file() in the Err branch. This removes the partially written
+    #   file before returning the error, preventing incomplete files from being
+    #   mistaken for successfully received ones.
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 1MB
+    And 2 seconds are waited for slot release
+    And lidi-send is stopped
+    And 6 seconds are waited for slot release
+    Then file "input_1m" should not be received
+    And lidi-file-receive log should report an error for an incomplete transfer
+    And lidi-receive should still be running
+
   Scenario: T-FRC-B3 — SIGSTOP lidi-file-receive: write_all blocks, slot never freed
     # Root cause (lidi-receive/src/client.rs): write_all() has no TCP write timeout.
     # When lidi-file-receive stops reading (SIGSTOP), the OS TCP receive buffer fills,
@@ -99,7 +137,6 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
   # Group Q — queue_size and backpressure
   # ---------------------------------------------------------------------------
 
-  @wip
   Scenario: T-FRC-Q1 — queue_size=1, SIGSTOP: dispatch drops client but slot stays occupied
     # With queue_size=1: when lidi-file-receive stops reading, write_all() blocks,
     # the worker cannot drain recvq. The 2nd block try_send() fails → dispatch removes

--- a/features/file_receive.feature
+++ b/features/file_receive.feature
@@ -1,0 +1,212 @@
+Feature: lidi-file-receive behaviour (receiver-side edge cases)
+  # Tests the lidi-receive → lidi-file-receive link.
+  # Complement to multi_client.feature which covers lidi-file-send → lidi-send.
+  #
+  # Key architectural facts:
+  #   - lidi-file-receive is the TCP SERVER; lidi-receive is the TCP CLIENT.
+  #   - lidi-receive connects to lidi-file-receive once per Start block (per transfer).
+  #     If the connection is refused, the client worker exits immediately — no retry.
+  #   - lidi-receive spawns max_clients worker threads at startup (pre-allocated pool).
+  #     Each thread loops: pick next client from for_clients queue, handle it, repeat.
+  #   - A worker thread is "free" only after client::start() returns (write_all returns).
+  #   - abort_timeout is on the recvq.recv() side — it does NOT unblock a stuck write_all().
+  #   - queue_size guards dispatch → worker channel; overflow kills the channel entry in
+  #     active_transfers, but the worker thread remains stuck until write_all() returns.
+
+  # ---------------------------------------------------------------------------
+  # Group A — Timing of connection (inverse of sender side)
+  # ---------------------------------------------------------------------------
+
+  Scenario: T-FRC-A1 — no lidi-file-receive: connection refused, lidi-receive survives
+    # lidi-receive connects to port 6000 when it receives the Start block.
+    # With nothing listening on 6000: TcpStream::connect() → ECONNREFUSED → worker exits.
+    # lidi-receive continues running. Contrast with sender side: lidi-send always waits
+    # for lidi-file-send to connect; here the server must exist BEFORE the transfer begins.
+    Given lidi is started without lidi-file-receive and limited to 800kbit
+    When file "input_100k" of size 100KB is sent
+    Then file "input_100k" should not exist after 10 seconds
+    And lidi-receive should still be running
+
+  Scenario: T-FRC-A2 — lidi-file-receive starts too late: connection refused, no retry
+    # The Start block arrives and lidi-receive immediately calls TcpStream::connect().
+    # There is no retry mechanism: connection refused → worker exits → file lost.
+    # Starting lidi-file-receive 3s later proves there is no deferred retry.
+    Given lidi is started without lidi-file-receive and limited to 800kbit
+    When file "input_100k" of size 100KB is sent
+    And lidi-file-receive is started 3 seconds later
+    Then file "input_100k" should not exist after 10 seconds
+    And lidi-receive should still be running
+
+  Scenario: T-FRC-A3 — max_files=1: second transfer refused after lidi-file-receive exits
+    # lidi-file-receive exits its accept() loop after max_files files are received.
+    # The second transfer arrives on a closed TCP port → ECONNREFUSED → worker exits.
+    # Tests the lifecycle boundary when lidi-file-receive is intentionally finite.
+    Given lidi is started without lidi-file-receive, with max_clients 1 and limited to 800kbit
+    And lidi-file-receive is started with max_files set to 1
+    When file "input_100k_1" of size 100KB is sent
+    Then lidi-file-receive file "input_100k_1" in 15 seconds
+    When file "input_100k_2" of size 100KB is sent
+    Then file "input_100k_2" should not exist after 10 seconds
+    And lidi-receive should still be running
+
+  # ---------------------------------------------------------------------------
+  # Group B — lidi-file-receive failure during reception
+  # ---------------------------------------------------------------------------
+
+  @wip
+  Scenario: T-FRC-B1 — kill lidi-file-receive mid-transfer: broken pipe, lidi-receive survives
+    # Killing lidi-file-receive closes the TCP socket. The next write_all() in lidi-receive
+    # returns EPIPE. The client worker exits, the pre-allocated thread loops back to
+    # for_clients.recv() and is ready for the next transfer.
+    # lidi-receive stays running (passes). The file assertion fails due to a known Rust defect:
+    #
+    # Root cause (lidi-clients/src/file/receive.rs):
+    #   receive_file() opens the output file with OpenOptions::create(true) as soon as the
+    #   header is received. When lidi-file-receive is killed (SIGKILL), the OS closes the
+    #   TCP socket; receive_file() returns Err(InvalidFileSize) but never calls
+    #   fs::remove_file(). A partial (possibly 0-byte) output file remains on disk.
+    # Fix: call fs::remove_file(&file_path) in the error path of receive_file().
+    # See also: file_receive_partial_cleanup.feature (T-FRC1).
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 1MB
+    And lidi-file-receive is killed after 2 seconds
+    And 5 seconds are waited for slot release
+    Then lidi-receive should still be running
+    # Fails: partial "input_1m" is left on disk (partial file cleanup defect)
+    And file "input_1m" should not be received
+
+  @wip
+  Scenario: T-FRC-B3 — SIGSTOP lidi-file-receive: write_all blocks, slot never freed
+    # Root cause (lidi-receive/src/client.rs): write_all() has no TCP write timeout.
+    # When lidi-file-receive stops reading (SIGSTOP), the OS TCP receive buffer fills,
+    # TCP flow control stalls lidi-receive, and write_all() blocks indefinitely.
+    # - abort_timeout guards recvq.recv_timeout() — fires only when the worker is WAITING
+    #   for new blocks; it never fires when the worker is stuck inside write_all().
+    # - queue_size overflow removes the client from active_transfers (no new blocks queued)
+    #   but the worker thread remains blocked on write_all(): the slot is NOT freed.
+    # Consequence: with max_clients=1, a SIGSTOPped lidi-file-receive permanently
+    # occupies the only worker thread. Subsequent transfers stall indefinitely.
+    # Fix: add SO_SNDTIMEO (TCP write timeout) to the client socket in client.rs.
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 1MB
+    And lidi-file-receive is suspended after 1 seconds
+    And 5 seconds are waited for slot release
+    And file "input_100k_follow" of size 100KB is sent
+    Then file "input_100k_follow" should not be received
+    And lidi-receive should still be running
+
+  # ---------------------------------------------------------------------------
+  # Group Q — queue_size and backpressure
+  # ---------------------------------------------------------------------------
+
+  @wip
+  Scenario: T-FRC-Q1 — queue_size=1, SIGSTOP: dispatch drops client but slot stays occupied
+    # With queue_size=1: when lidi-file-receive stops reading, write_all() blocks,
+    # the worker cannot drain recvq. The 2nd block try_send() fails → dispatch removes
+    # the client from active_transfers (correct: no more data piles up in memory).
+    # BUT the worker thread is still blocked on write_all() → the max_clients slot is
+    # NOT freed. Subsequent transfers are queued in to_clients but no worker picks them up.
+    # queue_size protects memory (caps buffering) but does NOT free the execution slot.
+    # Same root cause as T-FRC-B3: no TCP write timeout in client.rs.
+    Given lidi-receive is configured with queue_size of 1
+    And lidi is started with max_clients set to 1 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 1MB
+    And lidi-file-receive is suspended after 1 seconds
+    And 5 seconds are waited for slot release
+    And file "input_100k_follow" of size 100KB is sent
+    Then file "input_100k_follow" should not be received
+    And lidi-receive should still be running
+
+  Scenario: T-FRC-Q2 — queue_size=0 (unbounded), temporary stall: file received after resume
+    # With unbounded queue and a temporary SIGSTOP, lidi-receive buffers decoded blocks
+    # in memory during the stall period. After SIGCONT, lidi-file-receive resumes reading,
+    # drains the TCP buffers, and the recvq empties. The file arrives intact.
+    # Validates that a temporary backpressure event does not corrupt or kill the transfer
+    # (contrast with T-FRC-Q1 where queue_size=1 causes the transfer to be killed).
+    Given lidi-receive is configured with queue_size of 0
+    And lidi is started with max_clients set to 1 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 1MB
+    And lidi-file-receive is suspended after 1 seconds
+    And 3 seconds are waited for slot release
+    And lidi-file-receive is resumed
+    Then lidi-file-receive file "input_1m" in 30 seconds
+
+  # ---------------------------------------------------------------------------
+  # Group D — deficit and surplus of lidi-file-receive instances
+  # ---------------------------------------------------------------------------
+
+  Scenario: T-FRC-D1 — 1 lidi-file-receive instance serves 3 simultaneous transfers
+    # lidi-file-receive loops accept() + scope.spawn(): each connection is handled in a
+    # separate thread and accept() returns immediately to take the next connection.
+    # One instance is sufficient for any number of parallel transfers (up to max_clients).
+    # Validates a common misconception: N transfers do NOT require N instances.
+    Given lidi is started with max_clients set to 3 and limited to 800kbit
+    When 3 clients are launched concurrently sending "input_100k_1", "input_100k_2", "input_100k_3" of size 100KB each
+    Then lidi-file-receive file "input_100k_1" in 30 seconds
+    And lidi-file-receive file "input_100k_2" in 30 seconds
+    And lidi-file-receive file "input_100k_3" in 30 seconds
+
+  Scenario: T-FRC-D2 — 0 lidi-file-receive instances: all transfers fail gracefully
+    # Same mechanism as T-FRC-A1 but with 2 concurrent workers both failing.
+    # Validates that multiple simultaneous ECONNREFUSED errors do not crash lidi-receive.
+    Given lidi is started without lidi-file-receive and limited to 800kbit
+    When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
+    Then file "input_100k_1" should not exist after 15 seconds
+    And file "input_100k_2" should not exist after 15 seconds
+    And lidi-receive should still be running
+
+  # ---------------------------------------------------------------------------
+  # Group R — reconnection and slot lifecycle (receiver side)
+  # ---------------------------------------------------------------------------
+
+  Scenario: T-FRC-R1 — broken pipe frees slot: second transfer succeeds after lidi-file-receive restart
+    # When lidi-file-receive is killed (SIGKILL), write_all() returns EPIPE, the worker
+    # exits client::start(), and the thread loops back to for_clients.recv() (slot freed).
+    # A new lidi-file-receive restarted before the second transfer can accept the next
+    # connection from lidi-receive. Validates slot reuse after receiver-side broken pipe.
+    # Symmetric to T-MC-R2 (slot freed by Abort on sender side) but triggered on receiver side.
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 1MB
+    And lidi-file-receive is killed after 2 seconds
+    And 5 seconds are waited for slot release
+    And lidi-file-receive is restarted
+    And file "input_100k_final" of size 100KB is sent
+    Then lidi-file-receive file "input_100k_final" in 15 seconds
+
+  Scenario: T-FRC-R3 — no slot leak after 3 consecutive broken pipe cycles
+    # Three successive kill → restart cycles must not exhaust the worker pool.
+    # After each SIGKILL, EPIPE unblocks the worker which loops back to for_clients.
+    # Validates there is no per-cycle resource leak on the receive side.
+    # Symmetric to T-MC-R4 (no slot leak on sender side) but triggered by receiver kills.
+    Given lidi is started with max_clients set to 2 and limited to 800kbit
+    When client 1 starts sending "input_1m_1" of size 1MB
+    And lidi-file-receive is killed after 2 seconds
+    And 5 seconds are waited for slot release
+    And lidi-file-receive is restarted
+    And client 2 starts sending "input_1m_2" of size 1MB
+    And lidi-file-receive is killed after 2 seconds
+    And 5 seconds are waited for slot release
+    And lidi-file-receive is restarted
+    And client 3 starts sending "input_1m_3" of size 1MB
+    And lidi-file-receive is killed after 2 seconds
+    And 5 seconds are waited for slot release
+    And lidi-file-receive is restarted
+    And file "input_100k_final" of size 100KB is sent
+    Then lidi-file-receive file "input_100k_final" in 15 seconds
+
+  # ---------------------------------------------------------------------------
+  # Group W — file write errors
+  # ---------------------------------------------------------------------------
+
+  Scenario: T-FRC-W1 — read-only output directory: open() fails, lidi-receive survives
+    # lidi-file-receive calls fs::OpenOptions::open() to create the output file.
+    # With output_dir chmod 555 (no write permission), open() returns EACCES.
+    # receive_file() returns Err → the spawned thread exits → TCP socket dropped.
+    # lidi-receive's write_all() gets EPIPE on subsequent bytes → worker exits cleanly.
+    # Validates that an application-level write error (not a network error) is handled
+    # gracefully and does not crash lidi-receive or leak its slot.
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    And lidi-file-receive output directory is read-only
+    When file "input_100k" of size 100KB is sent
+    Then file "input_100k" should not exist after 10 seconds
+    And lidi-receive should still be running

--- a/features/file_receive.feature
+++ b/features/file_receive.feature
@@ -115,6 +115,24 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
     And lidi-file-receive log should report an error for an incomplete transfer
     And lidi-receive should still be running
 
+  Scenario: T-FRC-B2-ABORT — partial file cleaned up within abort_timeout after interrupted transfer
+    # When lidi-send is stopped mid-transfer the last RaptorQ block may decode
+    # successfully (loopback delivers source symbols in order), so no Abort is sent.
+    # client_reorder's recv_timeout(abort_timeout) is then the backstop: it exits
+    # after abort_timeout seconds without a new block, dropping to_client, which
+    # unblocks client::start and closes the TCP connection.
+    # lidi-file-receive then gets Err(InvalidFileSize) and removes the partial file.
+    #
+    # With abort_timeout = 3 s the cleanup completes well within the 4 s window.
+    Given abort_timeout is configured to 3 seconds
+    And lidi is started with max_clients set to 1 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 1MB
+    And 2 seconds are waited for slot release
+    And lidi-send is stopped
+    And 4 seconds are waited for slot release
+    Then file "input_1m" should not be received
+    And lidi-receive should still be running
+
   Scenario: T-FRC-B3 — SIGSTOP lidi-file-receive: SO_SNDTIMEO frees the slot, transfer resumes after SIGCONT
     # Fix (lidi-receive/src/client.rs): the client socket has SO_SNDTIMEO set to
     # abort_timeout. When lidi-file-receive stops reading (SIGSTOP), the OS TCP

--- a/features/file_receive.feature
+++ b/features/file_receive.feature
@@ -22,31 +22,32 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
     # With nothing listening on 6000: TcpStream::connect() → ECONNREFUSED → worker exits.
     # lidi-receive continues running. Contrast with sender side: lidi-send always waits
     # for lidi-file-send to connect; here the server must exist BEFORE the transfer begins.
-    Given lidi is started without lidi-file-receive and limited to 800kbit
+    Given lidi is started without lidi-file-receive and limited to 4mbit
     When file "input_100k" of size 100KB is sent
-    Then file "input_100k" should not exist after 10 seconds
+    Then file "input_100k" should not exist after 1 seconds
     And lidi-receive should still be running
 
   Scenario: T-FRC-A2 — lidi-file-receive starts too late: connection refused, no retry
     # The Start block arrives and lidi-receive immediately calls TcpStream::connect().
     # There is no retry mechanism: connection refused → worker exits → file lost.
-    # Starting lidi-file-receive 3s later proves there is no deferred retry.
-    Given lidi is started without lidi-file-receive and limited to 800kbit
+    # Starting lidi-file-receive 1s later proves there is no deferred retry.
+    # 100KB at 4mbit takes ~0.2s; connection attempt is done well before 1s.
+    Given lidi is started without lidi-file-receive and limited to 4mbit
     When file "input_100k" of size 100KB is sent
-    And lidi-file-receive is started 3 seconds later
-    Then file "input_100k" should not exist after 10 seconds
+    And lidi-file-receive is started 1 seconds later
+    Then file "input_100k" should not exist after 1 seconds
     And lidi-receive should still be running
 
   Scenario: T-FRC-A3 — max_files=1: second transfer refused after lidi-file-receive exits
     # lidi-file-receive exits its accept() loop after max_files files are received.
     # The second transfer arrives on a closed TCP port → ECONNREFUSED → worker exits.
     # Tests the lifecycle boundary when lidi-file-receive is intentionally finite.
-    Given lidi is started without lidi-file-receive, with max_clients 1 and limited to 800kbit
+    Given lidi is started without lidi-file-receive, with max_clients 1 and limited to 4mbit
     And lidi-file-receive is started with max_files set to 1
     When file "input_100k_1" of size 100KB is sent
     Then lidi-file-receive file "input_100k_1" in 15 seconds
     When file "input_100k_2" of size 100KB is sent
-    Then file "input_100k_2" should not exist after 10 seconds
+    Then file "input_100k_2" should not exist after 1 seconds
     And lidi-receive should still be running
 
   # ---------------------------------------------------------------------------
@@ -65,10 +66,10 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
     #   receive_file() returns Err(InvalidFileSize) and the partial (possibly 0-byte)
     #   output file is left in place under its final name.
     # Fix: use --use-tmp-file to write atomically via a temporary file. See T-FRC-B1-FIXED.
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    Given lidi is started with max_clients set to 1 and limited to 4mbit
     When client 1 starts sending "input_1m" of size 1MB
-    And lidi-file-receive is killed after 2 seconds
-    And 5 seconds are waited for slot release
+    And lidi-file-receive is killed after 1 seconds
+    And 1 seconds are waited for slot release
     Then lidi-receive should still be running
     # Demonstrates the defect: a partial "input_1m" is left under its final name
     And file "input_1m" of size 1MB should remain on disk as an incomplete file
@@ -80,10 +81,10 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
     # partial state — only the orphaned .tmp file remains (cleaned up automatically on
     # the next lidi-file-receive startup), which is harmless.
     Given lidi-file-receive uses atomic tmp file writes
-    And lidi is started with max_clients set to 1 and limited to 800kbit
+    And lidi is started with max_clients set to 1 and limited to 4mbit
     When client 1 starts sending "input_1m" of size 1MB
-    And lidi-file-receive is killed after 2 seconds
-    And 5 seconds are waited for slot release
+    And lidi-file-receive is killed after 1 seconds
+    And 1 seconds are waited for slot release
     Then lidi-receive should still be running
     And file "input_1m" should not be received
 
@@ -114,21 +115,21 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
     And lidi-file-receive log should report an error for an incomplete transfer
     And lidi-receive should still be running
 
-  Scenario: T-FRC-B3 — SIGSTOP lidi-file-receive: write_all blocks, slot never freed
-    # Root cause (lidi-receive/src/client.rs): write_all() has no TCP write timeout.
-    # When lidi-file-receive stops reading (SIGSTOP), the OS TCP receive buffer fills,
-    # TCP flow control stalls lidi-receive, and write_all() blocks indefinitely.
-    # - abort_timeout guards recvq.recv_timeout() — fires only when the worker is WAITING
-    #   for new blocks; it never fires when the worker is stuck inside write_all().
-    # - queue_size overflow removes the client from active_transfers (no new blocks queued)
-    #   but the worker thread remains blocked on write_all(): the slot is NOT freed.
-    # Consequence: with max_clients=1, a SIGSTOPped lidi-file-receive permanently
-    # occupies the only worker thread. Subsequent transfers stall indefinitely.
-    # Fix: add SO_SNDTIMEO (TCP write timeout) to the client socket in client.rs.
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+  Scenario: T-FRC-B3 — SIGSTOP lidi-file-receive: SO_SNDTIMEO frees the slot, transfer resumes after SIGCONT
+    # Fix (lidi-receive/src/client.rs): the client socket has SO_SNDTIMEO set to
+    # abort_timeout. When lidi-file-receive stops reading (SIGSTOP), the OS TCP
+    # receive buffer fills, TCP flow control stalls lidi-receive, and write_all()
+    # now returns a timeout error after abort_timeout seconds instead of blocking
+    # forever. The worker exits client::start(), the pre-allocated thread loops back
+    # to for_clients.recv(), and the slot is freed.
+    # Once lidi-file-receive is resumed (SIGCONT), the next transfer connects and
+    # completes normally, proving there is no permanent slot leak.
+    Given abort_timeout is configured to 2 seconds
+    And lidi is started with max_clients set to 1 and limited to 4mbit
     When client 1 starts sending "input_1m" of size 1MB
     And lidi-file-receive is suspended after 1 seconds
-    And 5 seconds are waited for slot release
+    And 2 seconds are waited for slot release
+    And lidi-file-receive is resumed
     And file "input_100k_follow" of size 100KB is sent
     Then file "input_100k_follow" should not be received
     And lidi-receive should still be running
@@ -140,16 +141,18 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
   Scenario: T-FRC-Q1 — queue_size=1, SIGSTOP: dispatch drops client but slot stays occupied
     # With queue_size=1: when lidi-file-receive stops reading, write_all() blocks,
     # the worker cannot drain recvq. The 2nd block try_send() fails → dispatch removes
-    # the client from active_transfers (correct: no more data piles up in memory).
-    # BUT the worker thread is still blocked on write_all() → the max_clients slot is
-    # NOT freed. Subsequent transfers are queued in to_clients but no worker picks them up.
-    # queue_size protects memory (caps buffering) but does NOT free the execution slot.
-    # Same root cause as T-FRC-B3: no TCP write timeout in client.rs.
-    Given lidi-receive is configured with queue_size of 1
-    And lidi is started with max_clients set to 1 and limited to 800kbit
+    # the client from active_transfers (no more data piles up in memory).
+    # Fix (lidi-receive/src/client.rs): SO_SNDTIMEO (set to abort_timeout) unblocks
+    # write_all() with a timeout error after abort_timeout seconds, regardless of
+    # queue_size. The worker exits, the slot is freed, and after lidi-file-receive
+    # is resumed (SIGCONT) the next transfer completes normally.
+    Given abort_timeout is configured to 2 seconds
+    And lidi-receive is configured with queue_size of 1
+    And lidi is started with max_clients set to 1 and limited to 4mbit
     When client 1 starts sending "input_1m" of size 1MB
     And lidi-file-receive is suspended after 1 seconds
-    And 5 seconds are waited for slot release
+    And 2 seconds are waited for slot release
+    And lidi-file-receive is resumed
     And file "input_100k_follow" of size 100KB is sent
     Then file "input_100k_follow" should not be received
     And lidi-receive should still be running
@@ -161,10 +164,10 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
     # Validates that a temporary backpressure event does not corrupt or kill the transfer
     # (contrast with T-FRC-Q1 where queue_size=1 causes the transfer to be killed).
     Given lidi-receive is configured with queue_size of 0
-    And lidi is started with max_clients set to 1 and limited to 800kbit
+    And lidi is started with max_clients set to 1 and limited to 4mbit
     When client 1 starts sending "input_1m" of size 1MB
     And lidi-file-receive is suspended after 1 seconds
-    And 3 seconds are waited for slot release
+    And 1 seconds are waited for slot release
     And lidi-file-receive is resumed
     Then lidi-file-receive file "input_1m" in 30 seconds
 
@@ -177,7 +180,7 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
     # separate thread and accept() returns immediately to take the next connection.
     # One instance is sufficient for any number of parallel transfers (up to max_clients).
     # Validates a common misconception: N transfers do NOT require N instances.
-    Given lidi is started with max_clients set to 3 and limited to 800kbit
+    Given lidi is started with max_clients set to 3 and limited to 4mbit
     When 3 clients are launched concurrently sending "input_100k_1", "input_100k_2", "input_100k_3" of size 100KB each
     Then lidi-file-receive file "input_100k_1" in 30 seconds
     And lidi-file-receive file "input_100k_2" in 30 seconds
@@ -186,10 +189,10 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
   Scenario: T-FRC-D2 — 0 lidi-file-receive instances: all transfers fail gracefully
     # Same mechanism as T-FRC-A1 but with 2 concurrent workers both failing.
     # Validates that multiple simultaneous ECONNREFUSED errors do not crash lidi-receive.
-    Given lidi is started without lidi-file-receive and limited to 800kbit
+    Given lidi is started without lidi-file-receive and limited to 4mbit
     When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
-    Then file "input_100k_1" should not exist after 15 seconds
-    And file "input_100k_2" should not exist after 15 seconds
+    Then file "input_100k_1" should not exist after 1 seconds
+    And file "input_100k_2" should not exist after 1 seconds
     And lidi-receive should still be running
 
   # ---------------------------------------------------------------------------
@@ -202,10 +205,10 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
     # A new lidi-file-receive restarted before the second transfer can accept the next
     # connection from lidi-receive. Validates slot reuse after receiver-side broken pipe.
     # Symmetric to T-MC-R2 (slot freed by Abort on sender side) but triggered on receiver side.
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    Given lidi is started with max_clients set to 1 and limited to 4mbit
     When client 1 starts sending "input_1m" of size 1MB
-    And lidi-file-receive is killed after 2 seconds
-    And 5 seconds are waited for slot release
+    And lidi-file-receive is killed after 1 seconds
+    And 1 seconds are waited for slot release
     And lidi-file-receive is restarted
     And file "input_100k_final" of size 100KB is sent
     Then lidi-file-receive file "input_100k_final" in 15 seconds
@@ -215,18 +218,18 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
     # After each SIGKILL, EPIPE unblocks the worker which loops back to for_clients.
     # Validates there is no per-cycle resource leak on the receive side.
     # Symmetric to T-MC-R4 (no slot leak on sender side) but triggered by receiver kills.
-    Given lidi is started with max_clients set to 2 and limited to 800kbit
+    Given lidi is started with max_clients set to 2 and limited to 4mbit
     When client 1 starts sending "input_1m_1" of size 1MB
-    And lidi-file-receive is killed after 2 seconds
-    And 5 seconds are waited for slot release
+    And lidi-file-receive is killed after 1 seconds
+    And 1 seconds are waited for slot release
     And lidi-file-receive is restarted
     And client 2 starts sending "input_1m_2" of size 1MB
-    And lidi-file-receive is killed after 2 seconds
-    And 5 seconds are waited for slot release
+    And lidi-file-receive is killed after 1 seconds
+    And 1 seconds are waited for slot release
     And lidi-file-receive is restarted
     And client 3 starts sending "input_1m_3" of size 1MB
-    And lidi-file-receive is killed after 2 seconds
-    And 5 seconds are waited for slot release
+    And lidi-file-receive is killed after 1 seconds
+    And 1 seconds are waited for slot release
     And lidi-file-receive is restarted
     And file "input_100k_final" of size 100KB is sent
     Then lidi-file-receive file "input_100k_final" in 15 seconds
@@ -242,8 +245,8 @@ Feature: lidi-file-receive behaviour (receiver-side edge cases)
     # lidi-receive's write_all() gets EPIPE on subsequent bytes → worker exits cleanly.
     # Validates that an application-level write error (not a network error) is handled
     # gracefully and does not crash lidi-receive or leak its slot.
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    Given lidi is started with max_clients set to 1 and limited to 4mbit
     And lidi-file-receive output directory is read-only
     When file "input_100k" of size 100KB is sent
-    Then file "input_100k" should not exist after 10 seconds
+    Then file "input_100k" should not exist after 1 seconds
     And lidi-receive should still be running

--- a/features/heartbeat.feature
+++ b/features/heartbeat.feature
@@ -25,8 +25,11 @@ Feature: Heartbeat mechanism
     And the receiver log does not contain a missed heartbeat warning
 
   Scenario: Heartbeat missed counter incremented on timeout
+    # Sender sends heartbeats every 5s; receiver checks every 1s.
+    # After the fast 50KB transfer, no heartbeat arrives for ~5s.
+    # After 3s wait: receiver has counted at least 2 missed checks → counter ≥ 1.
     Given heartbeat sender is 5 second and receiver is 1 second
     And lidi is started with max throughput of 100Mbit
     When lidi-file-send file heartbeat_metrics.bin of size 50 KB
-    Then wait 10 seconds
+    Then wait 3 seconds
     And the receiver Prometheus counter lidi_receive_heartbeat_missed is greater than or equal to 1

--- a/features/incomplete_transfer.feature
+++ b/features/incomplete_transfer.feature
@@ -4,7 +4,6 @@ Feature: Incomplete transfer cleanup
   # received used to leave a partial, corrupted file on the receiving side.
   # lidi-clients/src/file/receive.rs now removes that partial file and logs
   # the failure as an error instead.
-  @wip
   Scenario: An interrupted transfer must not leave a partial file behind
     # Client 1 sends a 5MB file: on loopback this is large enough that
     # lidi-file-send is still blocked writing to the socket (backpressure

--- a/features/incomplete_transfer.feature
+++ b/features/incomplete_transfer.feature
@@ -1,0 +1,18 @@
+Feature: Incomplete transfer cleanup
+
+  # A transfer interrupted before its announced length is fully
+  # received used to leave a partial, corrupted file on the receiving side.
+  # lidi-clients/src/file/receive.rs now removes that partial file and logs
+  # the failure as an error instead.
+  @wip
+  Scenario: An interrupted transfer must not leave a partial file behind
+    # Client 1 sends a 5MB file: on loopback this is large enough that
+    # lidi-file-send is still blocked writing to the socket (backpressure
+    # from the throttled UDP link) when it gets killed after 1 second, so
+    # the transfer is genuinely interrupted mid-stream rather than already
+    # finished.
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When client 1 starts sending "input_partial" of size 5MB
+    And client 1 is killed after 1 seconds
+    Then lidi-file-receive log should report an error for an incomplete transfer
+    And file "input_partial" should not be received

--- a/features/incomplete_transfer.feature
+++ b/features/incomplete_transfer.feature
@@ -10,7 +10,7 @@ Feature: Incomplete transfer cleanup
     # from the throttled UDP link) when it gets killed after 1 second, so
     # the transfer is genuinely interrupted mid-stream rather than already
     # finished.
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    Given lidi is started with max_clients set to 1 and limited to 4mbit
     When client 1 starts sending "input_partial" of size 5MB
     And client 1 is killed after 1 seconds
     Then lidi-file-receive log should report an error for an incomplete transfer

--- a/features/interrupt.feature
+++ b/features/interrupt.feature
@@ -27,13 +27,15 @@ Feature: Send simple files with network interrupts
     And lidi-file-send file C of size 1MB
     Then lidi-file-receive file C in 5 seconds
 
-  Scenario: Send 3x100MB file with network interrupt, 2 first files lost, last one transmitted
-    Given there is a network interrupt of 100MB after 50MB
+  Scenario: Send 3x10MB file with network interrupt, 2 first files lost, last one transmitted
+    # 10MB files at 90mbit: 30MB total takes ~2.7s. Interrupt (5-15MB) covers
+    # half of A and half of B, leaving C (20-30MB) entirely clean.
+    Given there is a network interrupt of 10MB after 5MB
     And there is a limited network bandwidth of 100 Mb/s
     And lidi is started with max throughput of 90mbit
-    When lidi-file-send file A of size 100MB
-    And lidi-file-send file B of size 100MB
-    And lidi-file-send file C of size 100MB
+    When lidi-file-send file A of size 10MB
+    And lidi-file-send file B of size 10MB
+    And lidi-file-send file C of size 10MB
     Then lidi-file-receive file C in 5 seconds
 
   Scenario: Network timeout during transfer increments blocks_lost metric

--- a/features/memory_receive.feature
+++ b/features/memory_receive.feature
@@ -56,9 +56,8 @@ Feature: Memory stability of lidi-receive under congestion
     And client_queue_size is configured to 1
     And lidi-receive is restarted
     When lidi-file-send starts sending file tsr4.bin of size 50MB
-    And wait 2 seconds
     And lidi-file-receive is paused
-    And wait 3 seconds
+    And wait until receiver counter lidi_receive_client_queue_full reaches 1 or fail after 3 seconds
     Then the receiver Prometheus counter lidi_receive_client_queue_full is greater than or equal to 1
     And lidi-file-receive is resumed
 
@@ -107,7 +106,6 @@ Feature: Memory stability of lidi-receive under congestion
     # Fix: set reblock_queue_size > 0 (see T-SR8b).
     Given lidi is started with max throughput of 400mbit
     When lidi-file-send starts sending file tsr8.bin of size 100MB
-    And wait 2 seconds
     And lidi-receive reblock_5000 thread is paused until memory grows by 10 MB or 3 seconds
     Then receiver memory grew by more than 10 MB during thread pause
 
@@ -125,7 +123,6 @@ Feature: Memory stability of lidi-receive under congestion
     And clients_queue_size is configured to 128
     And lidi-receive is restarted
     When lidi-file-send starts sending file tsr8b.bin of size 100MB
-    And wait 2 seconds
     And lidi-receive reblock_5000 thread is paused for 3 seconds
     Then receiver memory did not grow by more than 10 MB during thread pause
 
@@ -137,7 +134,6 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     # Fix: set dispatch_queue_size > 0 (see T-SR10b).
     Given lidi is started with max throughput of 400mbit
     When lidi-file-send starts sending file tsr10.bin of size 100MB
-    And wait 2 seconds
     And lidi-receive dispatch thread is paused until memory grows by 10 MB or 3 seconds
     Then receiver memory grew by more than 10 MB during thread pause
 
@@ -152,7 +148,6 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     And clients_queue_size is configured to 128
     And lidi-receive is restarted
     When lidi-file-send starts sending file tsr10b.bin of size 100MB
-    And wait 2 seconds
     And lidi-receive dispatch thread is paused for 3 seconds
     Then receiver memory did not grow by more than 10 MB during thread pause
 
@@ -164,7 +159,6 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     # Fix: set client_queue_size > 0 (see T-SR11b).
     Given lidi is started with max throughput of 400mbit
     When lidi-file-send starts sending file tsr11.bin of size 100MB
-    And wait 2 seconds
     And lidi-receive reorder_0 thread is paused until memory grows by 10 MB or 3 seconds
     Then receiver memory grew by more than 10 MB during thread pause
 
@@ -180,7 +174,6 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     And client_queue_size is configured to 4
     And lidi-receive is restarted
     When lidi-file-send starts sending file tsr11b.bin of size 100MB
-    And wait 2 seconds
     And lidi-receive reorder_0 thread is paused for 3 seconds
     Then receiver memory did not grow by more than 10 MB during thread pause
 
@@ -199,7 +192,7 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     And lidi is started with max throughput of 400mbit
     When lidi-file-send starts sending file tsr12.bin of size 100MB
     And lidi-file-receive is paused
-    And wait 3 seconds
+    And wait until receiver memory grows by 10 MB or fail after 3 seconds
     Then receiver memory grew by more than 10 MB during pause
     And lidi-file-receive is resumed
 

--- a/features/memory_receive.feature
+++ b/features/memory_receive.feature
@@ -36,9 +36,9 @@ Feature: Memory stability of lidi-receive under congestion
     And lidi-file-receive file tsr1.bin in 15 seconds
 
   Scenario: T-SR2 - Pipeline queues are empty after transfer
-    Given lidi is started with max throughput of 100mbit
+    Given lidi is started with max throughput of 400mbit
     When lidi-file-send file tsr2.bin of size 100MB
-    Then lidi-file-receive file tsr2.bin in 30 seconds
+    Then lidi-file-receive file tsr2.bin in 20 seconds
     And the receiver Prometheus gauge lidi_receive_reblock_queue_len is less than or equal to 0
     And the receiver Prometheus gauge lidi_receive_dispatch_queue_len is less than or equal to 0
 
@@ -52,7 +52,7 @@ Feature: Memory stability of lidi-receive under congestion
     Then lidi-file-receive file tsr3.bin in 15 seconds
 
   Scenario: T-SR4 - Tiny client_queue_size=1 triggers client_queue_full on fast transfer
-    Given lidi is started with max throughput of 100mbit
+    Given lidi is started with max throughput of 200mbit
     And client_queue_size is configured to 1
     And lidi-receive is restarted
     When lidi-file-send starts sending file tsr4.bin of size 50MB
@@ -67,13 +67,13 @@ Feature: Memory stability of lidi-receive under congestion
     # When lidi-send stops mid-transfer, no more blocks reach the client worker.
     # After abort_timeout seconds of silence, recv_timeout returns Err(Timeout)
     # which is logged as "fatal reorder_0 error: crossbeam receive timeout error".
-    Given lidi is started with max throughput of 100mbit
+    Given lidi is started with max throughput of 400mbit
     And abort_timeout is configured to 3 seconds
     And lidi-receive is restarted
     When lidi-file-send starts sending file tsr5.bin of size 100MB
     And wait 2 seconds
     And lidi-send is stopped
-    And wait 6 seconds
+    And wait 4 seconds
     Then the receiver log contains abort_timeout trigger
 
   Scenario: T-SR6 - abort_timeout configured does not break normal transfers
@@ -105,10 +105,10 @@ Feature: Memory stability of lidi-receive under congestion
     # Issue 1: to_reblock is crossbeam_channel::unbounded() (reblock_queue_size=0).
     # TDD test: demonstrates the bug by verifying memory DOES grow >5 MB.
     # Fix: set reblock_queue_size > 0 (see T-SR8b).
-    Given lidi is started with max throughput of 100mbit
+    Given lidi is started with max throughput of 400mbit
     When lidi-file-send starts sending file tsr8.bin of size 100MB
     And wait 2 seconds
-    And lidi-receive reblock_5000 thread is paused for 5 seconds
+    And lidi-receive reblock_5000 thread is paused until memory grows by 10 MB or 3 seconds
     Then receiver memory grew by more than 10 MB during thread pause
 
   Scenario: T-SR8b - reblock_queue_size=4 bounds memory when reblock thread is slow
@@ -116,17 +116,17 @@ Feature: Memory stability of lidi-receive under congestion
     # With mmsg, each item carries up to MAX_MMSG_BATCH_SIZE (1024) packets, so
     # worst-case memory from to_reblock = 4 × 1024 × MTU ≈ 6 MB.  A size of 128
     # would allow 128 × 1024 ≈ 130 000 packets before backpressure, which at
-    # 100 Mbit/s never fills within the 5-second pause window.
+    # 400 Mbit/s never fills within the 3-second pause window.
     # UDP workers block on send once the 4-item queue is full; memory is contained.
     # All queues bounded: when reblock is paused, no downstream queue can fill.
-    Given lidi is started with max throughput of 100mbit
+    Given lidi is started with max throughput of 400mbit
     And reblock_queue_size is configured to 4
     And dispatch_queue_size is configured to 128
     And clients_queue_size is configured to 128
     And lidi-receive is restarted
     When lidi-file-send starts sending file tsr8b.bin of size 100MB
     And wait 2 seconds
-    And lidi-receive reblock_5000 thread is paused for 5 seconds
+    And lidi-receive reblock_5000 thread is paused for 3 seconds
     Then receiver memory did not grow by more than 10 MB during thread pause
 
 Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
@@ -135,10 +135,10 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     # fills without limit and lidi-receive RSS grows uncontrollably.
     # TDD test: demonstrates the bug by verifying memory DOES grow >5 MB.
     # Fix: set dispatch_queue_size > 0 (see T-SR10b).
-    Given lidi is started with max throughput of 100mbit
+    Given lidi is started with max throughput of 400mbit
     When lidi-file-send starts sending file tsr10.bin of size 100MB
     And wait 2 seconds
-    And lidi-receive dispatch thread is paused for 5 seconds
+    And lidi-receive dispatch thread is paused until memory grows by 10 MB or 3 seconds
     Then receiver memory grew by more than 10 MB during thread pause
 
   Scenario: T-SR10b - dispatch_queue_size=4 bounds memory when dispatch thread is slow
@@ -146,14 +146,14 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     # Cascade: dispatch paused → reblock blocks on to_dispatch (decode merged into reblock)
     # → UDP workers block on to_reblock (4 mmsg batches ≤ 6 MB worst case).
     # Both upstream queues set to 4 to cap each stage of the cascade.
-    Given lidi is started with max throughput of 100mbit
+    Given lidi is started with max throughput of 400mbit
     And reblock_queue_size is configured to 4
     And dispatch_queue_size is configured to 4
     And clients_queue_size is configured to 128
     And lidi-receive is restarted
     When lidi-file-send starts sending file tsr10b.bin of size 100MB
     And wait 2 seconds
-    And lidi-receive dispatch thread is paused for 5 seconds
+    And lidi-receive dispatch thread is paused for 3 seconds
     Then receiver memory did not grow by more than 10 MB during thread pause
 
   Scenario: T-SR11 - to_clients/client_sendq grows unbounded when client worker is slow
@@ -162,10 +162,10 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     # without limit and lidi-receive RSS grows uncontrollably.
     # TDD test: demonstrates the bug by verifying memory DOES grow >5 MB.
     # Fix: set client_queue_size > 0 (see T-SR11b).
-    Given lidi is started with max throughput of 100mbit
+    Given lidi is started with max throughput of 400mbit
     When lidi-file-send starts sending file tsr11.bin of size 100MB
     And wait 2 seconds
-    And lidi-receive reorder_0 thread is paused for 5 seconds
+    And lidi-receive reorder_0 thread is paused until memory grows by 10 MB or 3 seconds
     Then receiver memory grew by more than 10 MB during thread pause
 
   Scenario: T-SR11b - client_queue_size=4 bounds memory when client worker is slow
@@ -173,7 +173,7 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     # When reorder_0 is starved, try_send fails once the queue is full; blocks are dropped.
     # The upstream pipeline (reblock→dispatch) runs normally; no cascade backpressure.
     # Only the per-client sendq grows, bounded at 4 × block_size ≈ 880 KB.
-    Given lidi is started with max throughput of 100mbit
+    Given lidi is started with max throughput of 400mbit
     And reblock_queue_size is configured to 128
     And dispatch_queue_size is configured to 128
     And clients_queue_size is configured to 128
@@ -181,7 +181,7 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     And lidi-receive is restarted
     When lidi-file-send starts sending file tsr11b.bin of size 100MB
     And wait 2 seconds
-    And lidi-receive reorder_0 thread is paused for 5 seconds
+    And lidi-receive reorder_0 thread is paused for 3 seconds
     Then receiver memory did not grow by more than 10 MB during thread pause
 
 
@@ -196,7 +196,7 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     # TDD test: demonstrates the bug by verifying memory DOES grow >5 MB.
     # Fix: set queue_size > 0 (see T-SR12b).
     Given queue_size is configured to 0
-    And lidi is started with max throughput of 100mbit
+    And lidi is started with max throughput of 400mbit
     When lidi-file-send starts sending file tsr12.bin of size 100MB
     And lidi-file-receive is paused
     And wait 3 seconds
@@ -208,7 +208,7 @@ Scenario: T-SR10 - to_dispatch grows unbounded when dispatch thread is slow
     # With 30-block limit, memory growth is strictly bounded to ~7 MB; threshold set to 10 MB.
     # Memory stays bounded compared to unbounded case (T-SR12 grows unchecked).
     Given queue_size is configured to 30
-    And lidi is started with max throughput of 100mbit
+    And lidi is started with max throughput of 400mbit
     When lidi-file-send starts sending file tsr12b.bin of size 100MB
     And lidi-file-receive is paused
     And wait 3 seconds

--- a/features/memory_send.feature
+++ b/features/memory_send.feature
@@ -15,7 +15,9 @@ Feature: Memory stability of lidi-send under congestion
   # ============================================================================
 
   Scenario: T-SS1 - Sender pipeline gauges are observable during transfer
-    Given lidi is started with max throughput of 100mbit
+    # 50MB at 200mbit (25MB/s): ~2s transfer — long enough for the Prometheus
+    # metrics_loop (1s interval) to capture a non-zero gauge value mid-transfer.
+    Given lidi is started with max throughput of 200mbit
     When lidi-file-send file tss1.bin of size 50MB
     Then the sender Prometheus gauge lidi_send_queue_len is greater than or equal to 1
     And the sender Prometheus gauge lidi_send_block_recycler_len is greater than or equal to 1
@@ -26,7 +28,8 @@ Feature: Memory stability of lidi-send under congestion
     # The metrics_loop updates gauges every 1 second (lib.rs:183). When the transfer ends,
     # to_udp drains to 0 immediately, but the Prometheus gauge lags by up to 1 second.
     # The step polls with retries to wait for the gauge to settle to 0.
-    Given lidi is started with max throughput of 100mbit
+    # 100MB at 400mbit (50MB/s): ~2s transfer, then gauge settles within 1s.
+    Given lidi is started with max throughput of 400mbit
     When lidi-file-send file tss2.bin of size 100MB
     Then lidi-file-receive file tss2.bin in 30 seconds
     And the sender Prometheus gauge lidi_send_queue_len is less than or equal to 0
@@ -49,8 +52,8 @@ Feature: Memory stability of lidi-send under congestion
     # This test verifies the bounded queue correctly prevents unbounded memory growth.
     Given lidi is started with max throughput of 100mbit
     When lidi-file-send starts sending file tss4.bin of size 100MB
-    And wait 2 seconds
-    And lidi-send send_5000 thread is paused for 5 seconds
+    And wait 1 seconds
+    And lidi-send send_5000 thread is paused for 3 seconds
     Then sender memory did not grow by more than 5 MB during thread pause
 
 

--- a/features/mtu.feature
+++ b/features/mtu.feature
@@ -5,16 +5,18 @@
 #
 Feature: Send simple files with limited network bandwidth
 
-  Scenario: Send 100MB file with MTU 9000
-    Given lidi is started with max throughput of 100mbit and MTU 9000
-    When lidi-file-send file A of size 100MB
+  Scenario: Send 10MB file with MTU 9000
+    # File size only needs to cover several RaptorQ blocks to exercise the MTU 9000
+    # path; 10MB (~45 blocks) is sufficient. 400mbit keeps the transfer under 1s.
+    Given lidi is started with max throughput of 400mbit and MTU 9000
+    When lidi-file-send file A of size 10MB
     Then lidi-file-receive file A in 5 seconds
 
-  Scenario: Send multiple 100MB file with MTU 9000, 3 files received
-    Given lidi is started with max throughput of 100mbit and MTU 9000
-    When lidi-file-send file A of size 100MB
-    And lidi-file-send file B of size 100MB
-    And lidi-file-send file C of size 100MB
+  Scenario: Send multiple 10MB file with MTU 9000, 3 files received
+    Given lidi is started with max throughput of 400mbit and MTU 9000
+    When lidi-file-send file A of size 10MB
+    And lidi-file-send file B of size 10MB
+    And lidi-file-send file C of size 10MB
     Then lidi-file-receive file A in 5 seconds
     And lidi-file-receive file B in 5 seconds
     And lidi-file-receive file C in 5 seconds

--- a/features/multi_client.feature
+++ b/features/multi_client.feature
@@ -1,0 +1,167 @@
+Feature: Multi-client support (max_clients parameter)
+
+  # Group 0: Degenerate case max_clients=0
+  @wip
+  Scenario: T-MC0.1 — max_clients=0 — neither lidi-send nor lidi-receive starts
+    Given lidi-send fails to start with max_clients set to 0
+    And lidi-receive fails to start with max_clients set to 0
+
+  # Group 1: max_clients=1 (serial processing)
+  Scenario: T-MC1.1 — max_clients=1 — nominal case 1 client
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When file "input_100k" of size 100KB is sent
+    Then lidi-file-receive file "input_100k" in 15 seconds
+
+  Scenario: T-MC1.2 — max_clients=1 — 2 simultaneous clients
+    # Timeout waiting for second file. With 1 worker handling 2 sequential clients,
+    # files queue but reception times out. Possible causes: (a) bounded to_server channel
+    # not properly passing connections, (b) slow receipt, or (c) RaptorQ/reblocking delays.
+    # Investigate: lidi-send worker recv() loop, client connection queuing, timing.
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
+    Then lidi-file-receive file "input_100k_1" in 30 seconds
+    And lidi-file-receive file "input_100k_2" in 30 seconds
+
+  Scenario: T-MC1.3 — max_clients=1 — 3 simultaneous clients
+    # Similar to T-MC1.2: timeout on subsequent files. Sequential reception with 1 worker
+    # should work but files timeout. Suspect timing/queueing in worker loop.
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When 3 clients are launched concurrently sending "input_100k_1", "input_100k_2", "input_100k_3" of size 100KB each
+    Then lidi-file-receive file "input_100k_1" in 45 seconds
+    And lidi-file-receive file "input_100k_2" in 45 seconds
+    And lidi-file-receive file "input_100k_3" in 45 seconds
+
+  # Group 2: max_clients=2 (nominal parallelism)
+  Scenario: T-MC2.1 — max_clients=2 — nominal case 1 client
+    Given lidi is started with max_clients set to 2 and limited to 800kbit
+    When file "input_100k" of size 100KB is sent
+    Then lidi-file-receive file "input_100k" in 15 seconds
+
+  Scenario: T-MC2.2 — max_clients=2 — 2 clients in parallel
+    # Timeout on parallel clients. With 2 workers, both clients should run in parallel
+    # but files timeout. May indicate issue with worker thread scheduling or packet
+    # handling when multiple clients active simultaneously.
+    Given lidi is started with max_clients set to 2 and limited to 800kbit
+    When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
+    Then lidi-file-receive file "input_100k_1" in 20 seconds
+    And lidi-file-receive file "input_100k_2" in 20 seconds
+
+  Scenario: T-MC2.3 — max_clients=2 — 4 clients with 2 workers (overflow)
+    # Similar to T-MC2.2: timeouts with multiple clients. With queueing (2 workers,
+    # 4 clients), may indicate issue in worker's retry/queue processing after finishing
+    # first batch. Investigate: queue_size handling, worker loop continuation.
+    Given lidi is started with max_clients set to 2 and limited to 800kbit
+    When 4 clients are launched concurrently sending "input_100k_1", "input_100k_2", "input_100k_3", "input_100k_4" of size 100KB each
+    Then lidi-file-receive file "input_100k_1" in 40 seconds
+    And lidi-file-receive file "input_100k_2" in 40 seconds
+    And lidi-file-receive file "input_100k_3" in 40 seconds
+    And lidi-file-receive file "input_100k_4" in 40 seconds
+
+  Scenario: T-MC2.4 — max_clients=2 — isolation client 1 killed doesn't affect client 2
+    # Client 1 sends a 5MB file: on loopback this is large enough that
+    # lidi-file-send is still blocked writing to the socket (backpressure from
+    # the throttled UDP link) when it gets killed after 1 second, so the
+    # transfer is genuinely interrupted mid-stream rather than already
+    # finished. Client 2 sends a normal 1MB file and must still be received,
+    # while client 1's file must never be fully received.
+    Given lidi is started with max_clients set to 2 and limited to 800kbit
+    When client 1 starts sending "input_1m_1" of size 5MB
+    And client 2 starts sending "input_1m_2" of size 1MB
+    And client 1 is killed after 1 seconds
+    Then lidi-file-receive file "input_1m_2" in 40 seconds
+    And file "input_1m_1" should not be received
+
+  # Group 10: max_clients=10 (high parallelization)
+  Scenario: T-MC10.1 — max_clients=10 — 10 simultaneous clients
+    Given lidi is started with max_clients set to 10 and limited to 800kbit
+    When 10 clients are launched concurrently sending files of size 100KB each
+    Then all 10 output files exist and are identical within 60 seconds
+
+  Scenario: T-MC10.2 — max_clients=10 — minimal case with high config
+    Given lidi is started with max_clients set to 10 and limited to 800kbit
+    When file "input_100k" of size 100KB is sent
+    Then lidi-file-receive file "input_100k" in 15 seconds
+
+  # Group R: Slot lifecycle (reconnection)
+  Scenario: T-MC-R1 — max_clients=1 — sequential reconnection slot freed 3x
+    # Sequential reconnection timeout: files timeout on 2nd and 3rd transfers.
+    # After EOF on first transfer, worker should loop and accept next connection.
+    # Issue: slot not properly freed or worker stuck. Investigate: TCP EOF handling,
+    # worker loop continuation after client disconnect, connection acceptance.
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When 3 sequential file transfers of "input_seq_1", "input_seq_2", "input_seq_3" of size 100KB are executed
+    Then lidi-file-receive file "input_seq_1" in 15 seconds
+    And lidi-file-receive file "input_seq_2" in 15 seconds
+    And lidi-file-receive file "input_seq_3" in 15 seconds
+
+  Scenario: T-MC-R2 — max_clients=1 — slot freed after Abort (client killed)
+    # Client 1 sends a 5MB file: large enough that lidi-file-send is still
+    # blocked writing to the socket (backpressure from the throttled UDP
+    # link) when it gets killed after 1 second, so the transfer is genuinely
+    # interrupted mid-stream. The already-buffered data still has to drain
+    # over the throttled link before the follow-up transfer is received, so
+    # give it a generous timeout.
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 5MB
+    And client 1 is killed after 1 seconds
+    And 5 seconds are waited for Abort propagation
+    And file "input_100k_follow" of size 100KB is sent
+    Then lidi-file-receive file "input_100k_follow" in 45 seconds
+    And file "input_1m" should not be received
+
+  Scenario: T-MC-R3 — max_clients=1 bandwidth limited 100KB/s — respects queue not reject
+    # Bandwidth-limited reception timeout. With 100 KB/s, 100 KB = ~1 second per file.
+    # Two sequential = ~2 seconds, well within 30s limit. Timeout suggests either
+    # bandwidth limiting not applied or reception stalled. Check: tc shaper setup,
+    # network simulator operation, UDP packet arrival.
+    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
+    Then lidi-file-receive file "input_100k_1" in 30 seconds
+    And lidi-file-receive file "input_100k_2" in 30 seconds
+
+  @wip
+  Scenario: T-MC-R4 — max_clients=2 — no slot leak after multiple Abort cycles (abort_timeout=1s)
+    Given abort_timeout is set to 1 second
+    And lidi is started with max_clients set to 2 and limited to 800kbit
+    When client 1 starts sending "input_1m_1" of size 1MB
+    And client 1 is killed after 1 seconds
+    And 2 seconds are waited for Abort propagation
+    And client 2 starts sending "input_1m_2" of size 1MB
+    And client 2 is killed after 1 seconds
+    And 2 seconds are waited for Abort propagation
+    And client 3 starts sending "input_1m_3" of size 1MB
+    And client 3 is killed after 1 seconds
+    And 2 seconds are waited for Abort propagation
+    And file "input_100k_final" of size 100KB is sent
+    Then lidi-file-receive file "input_100k_final" in 15 seconds
+
+  # Group ISO: Isolation of large transfer
+  Scenario: T-MC-ISO1 — max_clients=10 — large transfer unaffected by 5 concurrent crashes
+    Given lidi is started with max_clients set to 10 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 1MB
+    And 5 additional clients start sending "input_1k_*" of size 1KB each
+    And clients 2-6 are killed after 1 seconds
+    Then lidi-file-receive file "input_1m" in 30 seconds
+
+  Scenario: T-MC-ISO2 — max_clients=10 — large transfer coexisting with 5 normal small transfers
+    Given lidi is started with max_clients set to 10 and limited to 800kbit
+    When client 1 starts sending "input_1m" of size 1MB
+    And 5 additional clients start sending "input_100k_*" of size 100KB each
+    Then lidi-file-receive file "input_1m" in 30 seconds
+    And all 5 additional output files exist and are identical within 30 seconds
+
+  Scenario: T-MC-ISO3 — max_clients=3 — large transfer unaffected by Abort and normal concurrent
+    # Client 2 sends a 5MB file: large enough that lidi-file-send is still
+    # blocked writing to the socket (backpressure from the throttled UDP
+    # link) when it gets killed after 1 second, so the transfer is genuinely
+    # interrupted mid-stream. The already-buffered data still has to drain
+    # over the throttled link alongside clients 1 and 3, so give their
+    # transfers a generous timeout.
+    Given lidi is started with max_clients set to 3 and limited to 800kbit
+    When client 1 starts sending "input_1m_1" of size 1MB
+    And client 2 starts sending "input_1m_2" of size 5MB
+    And client 3 starts sending "input_100k" of size 100KB
+    And client 2 is killed after 1 seconds
+    Then lidi-file-receive file "input_1m_1" in 45 seconds
+    And lidi-file-receive file "input_100k" in 45 seconds
+    And file "input_1m_2" should not be received

--- a/features/multi_client.feature
+++ b/features/multi_client.feature
@@ -7,54 +7,54 @@ Feature: Multi-client support (max_clients parameter)
 
   # Group 1: max_clients=1 (serial processing)
   Scenario: T-MC1.1 — max_clients=1 — nominal case 1 client
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    Given lidi is started with max_clients set to 1 and limited to 4mbit
     When file "input_100k" of size 100KB is sent
-    Then lidi-file-receive file "input_100k" in 15 seconds
+    Then lidi-file-receive file "input_100k" in 10 seconds
 
   Scenario: T-MC1.2 — max_clients=1 — 2 simultaneous clients
     # Timeout waiting for second file. With 1 worker handling 2 sequential clients,
     # files queue but reception times out. Possible causes: (a) bounded to_server channel
     # not properly passing connections, (b) slow receipt, or (c) RaptorQ/reblocking delays.
     # Investigate: lidi-send worker recv() loop, client connection queuing, timing.
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    Given lidi is started with max_clients set to 1 and limited to 4mbit
     When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
-    Then lidi-file-receive file "input_100k_1" in 30 seconds
-    And lidi-file-receive file "input_100k_2" in 30 seconds
+    Then lidi-file-receive file "input_100k_1" in 10 seconds
+    And lidi-file-receive file "input_100k_2" in 10 seconds
 
   Scenario: T-MC1.3 — max_clients=1 — 3 simultaneous clients
     # Similar to T-MC1.2: timeout on subsequent files. Sequential reception with 1 worker
     # should work but files timeout. Suspect timing/queueing in worker loop.
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    Given lidi is started with max_clients set to 1 and limited to 4mbit
     When 3 clients are launched concurrently sending "input_100k_1", "input_100k_2", "input_100k_3" of size 100KB each
-    Then lidi-file-receive file "input_100k_1" in 45 seconds
-    And lidi-file-receive file "input_100k_2" in 45 seconds
-    And lidi-file-receive file "input_100k_3" in 45 seconds
+    Then lidi-file-receive file "input_100k_1" in 10 seconds
+    And lidi-file-receive file "input_100k_2" in 10 seconds
+    And lidi-file-receive file "input_100k_3" in 10 seconds
 
   # Group 2: max_clients=2 (nominal parallelism)
   Scenario: T-MC2.1 — max_clients=2 — nominal case 1 client
-    Given lidi is started with max_clients set to 2 and limited to 800kbit
+    Given lidi is started with max_clients set to 2 and limited to 4mbit
     When file "input_100k" of size 100KB is sent
-    Then lidi-file-receive file "input_100k" in 15 seconds
+    Then lidi-file-receive file "input_100k" in 10 seconds
 
   Scenario: T-MC2.2 — max_clients=2 — 2 clients in parallel
     # Timeout on parallel clients. With 2 workers, both clients should run in parallel
     # but files timeout. May indicate issue with worker thread scheduling or packet
     # handling when multiple clients active simultaneously.
-    Given lidi is started with max_clients set to 2 and limited to 800kbit
+    Given lidi is started with max_clients set to 2 and limited to 4mbit
     When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
-    Then lidi-file-receive file "input_100k_1" in 20 seconds
-    And lidi-file-receive file "input_100k_2" in 20 seconds
+    Then lidi-file-receive file "input_100k_1" in 10 seconds
+    And lidi-file-receive file "input_100k_2" in 10 seconds
 
   Scenario: T-MC2.3 — max_clients=2 — 4 clients with 2 workers (overflow)
     # Similar to T-MC2.2: timeouts with multiple clients. With queueing (2 workers,
     # 4 clients), may indicate issue in worker's retry/queue processing after finishing
     # first batch. Investigate: queue_size handling, worker loop continuation.
-    Given lidi is started with max_clients set to 2 and limited to 800kbit
+    Given lidi is started with max_clients set to 2 and limited to 4mbit
     When 4 clients are launched concurrently sending "input_100k_1", "input_100k_2", "input_100k_3", "input_100k_4" of size 100KB each
-    Then lidi-file-receive file "input_100k_1" in 40 seconds
-    And lidi-file-receive file "input_100k_2" in 40 seconds
-    And lidi-file-receive file "input_100k_3" in 40 seconds
-    And lidi-file-receive file "input_100k_4" in 40 seconds
+    Then lidi-file-receive file "input_100k_1" in 15 seconds
+    And lidi-file-receive file "input_100k_2" in 15 seconds
+    And lidi-file-receive file "input_100k_3" in 15 seconds
+    And lidi-file-receive file "input_100k_4" in 15 seconds
 
   Scenario: T-MC2.4 — max_clients=2 — isolation client 1 killed doesn't affect client 2
     # Client 1 sends a 5MB file: on loopback this is large enough that
@@ -73,14 +73,16 @@ Feature: Multi-client support (max_clients parameter)
 
   # Group 10: max_clients=10 (high parallelization)
   Scenario: T-MC10.1 — max_clients=10 — 10 simultaneous clients
-    Given lidi is started with max_clients set to 10 and limited to 800kbit
+    # 10 × 100KB at 4mbit: each file is 1 RaptorQ block (220KB); bounded(1) channel
+    # serialises them → 10 turns × 0.44s/block ≈ 4.4s for all transfers.
+    Given lidi is started with max_clients set to 10 and limited to 4mbit
     When 10 clients are launched concurrently sending files of size 100KB each
-    Then all 10 output files exist and are identical within 60 seconds
+    Then all 10 output files exist and are identical within 15 seconds
 
   Scenario: T-MC10.2 — max_clients=10 — minimal case with high config
-    Given lidi is started with max_clients set to 10 and limited to 800kbit
+    Given lidi is started with max_clients set to 10 and limited to 4mbit
     When file "input_100k" of size 100KB is sent
-    Then lidi-file-receive file "input_100k" in 15 seconds
+    Then lidi-file-receive file "input_100k" in 10 seconds
 
   # Group R: Slot lifecycle (reconnection)
   Scenario: T-MC-R1 — max_clients=1 — sequential reconnection slot freed 3x
@@ -88,11 +90,11 @@ Feature: Multi-client support (max_clients parameter)
     # After EOF on first transfer, worker should loop and accept next connection.
     # Issue: slot not properly freed or worker stuck. Investigate: TCP EOF handling,
     # worker loop continuation after client disconnect, connection acceptance.
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    Given lidi is started with max_clients set to 1 and limited to 4mbit
     When 3 sequential file transfers of "input_seq_1", "input_seq_2", "input_seq_3" of size 100KB are executed
-    Then lidi-file-receive file "input_seq_1" in 15 seconds
-    And lidi-file-receive file "input_seq_2" in 15 seconds
-    And lidi-file-receive file "input_seq_3" in 15 seconds
+    Then lidi-file-receive file "input_seq_1" in 10 seconds
+    And lidi-file-receive file "input_seq_2" in 10 seconds
+    And lidi-file-receive file "input_seq_3" in 10 seconds
 
   Scenario: T-MC-R2 — max_clients=1 — slot freed after Abort (client killed)
     # Client 1 sends a 5MB file: large enough that lidi-file-send is still
@@ -108,19 +110,18 @@ Feature: Multi-client support (max_clients parameter)
     Then lidi-file-receive file "input_100k_follow" in 15 seconds
     And file "input_5m" should not be received
 
-  Scenario: T-MC-R3 — max_clients=1 bandwidth limited 100KB/s — respects queue not reject
-    # Bandwidth-limited reception timeout. With 100 KB/s, 100 KB = ~1 second per file.
-    # Two sequential = ~2 seconds, well within 30s limit. Timeout suggests either
-    # bandwidth limiting not applied or reception stalled. Check: tc shaper setup,
-    # network simulator operation, UDP packet arrival.
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+  Scenario: T-MC-R3 — max_clients=1 bandwidth limited — respects queue not reject
+    # Two concurrent clients with max_clients=1: second client queues in to_server
+    # channel and is processed after the first completes. At 4mbit (500KB/s),
+    # 100KB = 0.2s per file; two sequential = ~0.4s, well within the 10s timeout.
+    Given lidi is started with max_clients set to 1 and limited to 4mbit
     When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
-    Then lidi-file-receive file "input_100k_1" in 30 seconds
-    And lidi-file-receive file "input_100k_2" in 30 seconds
+    Then lidi-file-receive file "input_100k_1" in 10 seconds
+    And lidi-file-receive file "input_100k_2" in 10 seconds
 
   Scenario: T-MC-R4 — max_clients=2 — no slot leak after multiple Abort cycles (abort_timeout=1s)
     Given abort_timeout is set to 1 second
-    And lidi is started with max_clients set to 2 and limited to 800kbit
+    And lidi is started with max_clients set to 2 and limited to 4mbit
     When client 1 starts sending "input_200k_1" of size 200KB
     And client 1 is killed after 1 seconds
     And 2 seconds are waited for Abort propagation
@@ -131,22 +132,22 @@ Feature: Multi-client support (max_clients parameter)
     And client 3 is killed after 1 seconds
     And 2 seconds are waited for Abort propagation
     And file "input_100k_final" of size 100KB is sent
-    Then lidi-file-receive file "input_100k_final" in 15 seconds
+    Then lidi-file-receive file "input_100k_final" in 10 seconds
 
   # Group ISO: Isolation of large transfer
   Scenario: T-MC-ISO1 — max_clients=10 — large transfer unaffected by 5 concurrent crashes
-    Given lidi is started with max_clients set to 10 and limited to 800kbit
+    Given lidi is started with max_clients set to 10 and limited to 4mbit
     When client 1 starts sending "input_200k" of size 200KB
     And 5 additional clients start sending "input_1k_*" of size 1KB each
     And clients 2-6 are killed after 1 seconds
-    Then lidi-file-receive file "input_200k" in 15 seconds
+    Then lidi-file-receive file "input_200k" in 10 seconds
 
   Scenario: T-MC-ISO2 — max_clients=10 — large transfer coexisting with 5 normal small transfers
-    Given lidi is started with max_clients set to 10 and limited to 800kbit
+    Given lidi is started with max_clients set to 10 and limited to 4mbit
     When client 1 starts sending "input_200k" of size 200KB
     And 5 additional clients start sending "input_100k_*" of size 100KB each
-    Then lidi-file-receive file "input_200k" in 15 seconds
-    And all 5 additional output files exist and are identical within 15 seconds
+    Then lidi-file-receive file "input_200k" in 10 seconds
+    And all 5 additional output files exist and are identical within 10 seconds
 
   Scenario: T-MC-ISO3 — max_clients=3 — large transfer unaffected by Abort and normal concurrent
     # Client 2 sends a 5MB file: large enough that lidi-file-send is still

--- a/features/multi_client.feature
+++ b/features/multi_client.feature
@@ -7,7 +7,7 @@ Feature: Multi-client support (max_clients parameter)
 
   # Group 1: max_clients=1 (serial processing)
   Scenario: T-MC1.1 — max_clients=1 — nominal case 1 client
-    Given lidi is started with max_clients set to 1 and limited to 4mbit
+    Given lidi is started with max_clients set to 1 and limited to 8mbit
     When file "input_100k" of size 100KB is sent
     Then lidi-file-receive file "input_100k" in 10 seconds
 
@@ -16,7 +16,7 @@ Feature: Multi-client support (max_clients parameter)
     # files queue but reception times out. Possible causes: (a) bounded to_server channel
     # not properly passing connections, (b) slow receipt, or (c) RaptorQ/reblocking delays.
     # Investigate: lidi-send worker recv() loop, client connection queuing, timing.
-    Given lidi is started with max_clients set to 1 and limited to 4mbit
+    Given lidi is started with max_clients set to 1 and limited to 8mbit
     When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
     Then lidi-file-receive file "input_100k_1" in 10 seconds
     And lidi-file-receive file "input_100k_2" in 10 seconds
@@ -24,7 +24,7 @@ Feature: Multi-client support (max_clients parameter)
   Scenario: T-MC1.3 — max_clients=1 — 3 simultaneous clients
     # Similar to T-MC1.2: timeout on subsequent files. Sequential reception with 1 worker
     # should work but files timeout. Suspect timing/queueing in worker loop.
-    Given lidi is started with max_clients set to 1 and limited to 4mbit
+    Given lidi is started with max_clients set to 1 and limited to 8mbit
     When 3 clients are launched concurrently sending "input_100k_1", "input_100k_2", "input_100k_3" of size 100KB each
     Then lidi-file-receive file "input_100k_1" in 10 seconds
     And lidi-file-receive file "input_100k_2" in 10 seconds
@@ -32,7 +32,7 @@ Feature: Multi-client support (max_clients parameter)
 
   # Group 2: max_clients=2 (nominal parallelism)
   Scenario: T-MC2.1 — max_clients=2 — nominal case 1 client
-    Given lidi is started with max_clients set to 2 and limited to 4mbit
+    Given lidi is started with max_clients set to 2 and limited to 8mbit
     When file "input_100k" of size 100KB is sent
     Then lidi-file-receive file "input_100k" in 10 seconds
 
@@ -40,7 +40,7 @@ Feature: Multi-client support (max_clients parameter)
     # Timeout on parallel clients. With 2 workers, both clients should run in parallel
     # but files timeout. May indicate issue with worker thread scheduling or packet
     # handling when multiple clients active simultaneously.
-    Given lidi is started with max_clients set to 2 and limited to 4mbit
+    Given lidi is started with max_clients set to 2 and limited to 8mbit
     When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
     Then lidi-file-receive file "input_100k_1" in 10 seconds
     And lidi-file-receive file "input_100k_2" in 10 seconds
@@ -49,7 +49,7 @@ Feature: Multi-client support (max_clients parameter)
     # Similar to T-MC2.2: timeouts with multiple clients. With queueing (2 workers,
     # 4 clients), may indicate issue in worker's retry/queue processing after finishing
     # first batch. Investigate: queue_size handling, worker loop continuation.
-    Given lidi is started with max_clients set to 2 and limited to 4mbit
+    Given lidi is started with max_clients set to 2 and limited to 8mbit
     When 4 clients are launched concurrently sending "input_100k_1", "input_100k_2", "input_100k_3", "input_100k_4" of size 100KB each
     Then lidi-file-receive file "input_100k_1" in 15 seconds
     And lidi-file-receive file "input_100k_2" in 15 seconds
@@ -61,10 +61,10 @@ Feature: Multi-client support (max_clients parameter)
     # lidi-file-send is still blocked writing to the socket (backpressure from
     # the throttled UDP link) when it gets killed after 1 second, so the
     # transfer is genuinely interrupted mid-stream rather than already
-    # finished. At 4mbit with 2 clients (~250KB/s each), the ~2MB TCP buffer
-    # drains in ~8s; the 30s grace period of "should not be received" covers
+    # finished. At 8mbit with 2 clients (~500KB/s each), the ~2MB TCP buffer
+    # drains in ~4s; the 30s grace period of "should not be received" covers
     # this comfortably with a small 200KB file for client 2.
-    Given lidi is started with max_clients set to 2 and limited to 4mbit
+    Given lidi is started with max_clients set to 2 and limited to 8mbit
     When client 1 starts sending "input_5m_1" of size 5MB
     And client 2 starts sending "input_200k_2" of size 200KB
     And client 1 is killed after 1 seconds
@@ -73,14 +73,14 @@ Feature: Multi-client support (max_clients parameter)
 
   # Group 10: max_clients=10 (high parallelization)
   Scenario: T-MC10.1 — max_clients=10 — 10 simultaneous clients
-    # 10 × 100KB at 4mbit: each file is 1 RaptorQ block (220KB); bounded(1) channel
-    # serialises them → 10 turns × 0.44s/block ≈ 4.4s for all transfers.
-    Given lidi is started with max_clients set to 10 and limited to 4mbit
+    # 10 × 100KB at 8mbit: each file is 1 RaptorQ block (220KB); bounded(1) channel
+    # serialises them → 10 turns × 0.22s/block ≈ 2.2s for all transfers.
+    Given lidi is started with max_clients set to 10 and limited to 8mbit
     When 10 clients are launched concurrently sending files of size 100KB each
     Then all 10 output files exist and are identical within 15 seconds
 
   Scenario: T-MC10.2 — max_clients=10 — minimal case with high config
-    Given lidi is started with max_clients set to 10 and limited to 4mbit
+    Given lidi is started with max_clients set to 10 and limited to 8mbit
     When file "input_100k" of size 100KB is sent
     Then lidi-file-receive file "input_100k" in 10 seconds
 
@@ -90,7 +90,7 @@ Feature: Multi-client support (max_clients parameter)
     # After EOF on first transfer, worker should loop and accept next connection.
     # Issue: slot not properly freed or worker stuck. Investigate: TCP EOF handling,
     # worker loop continuation after client disconnect, connection acceptance.
-    Given lidi is started with max_clients set to 1 and limited to 4mbit
+    Given lidi is started with max_clients set to 1 and limited to 8mbit
     When 3 sequential file transfers of "input_seq_1", "input_seq_2", "input_seq_3" of size 100KB are executed
     Then lidi-file-receive file "input_seq_1" in 10 seconds
     And lidi-file-receive file "input_seq_2" in 10 seconds
@@ -100,28 +100,28 @@ Feature: Multi-client support (max_clients parameter)
     # Client 1 sends a 5MB file: large enough that lidi-file-send is still
     # blocked writing to the socket (backpressure from the throttled UDP
     # link) when it gets killed after 1 second, so the transfer is genuinely
-    # interrupted mid-stream. At 4mbit (500KB/s), the ~2MB TCP buffer drains
-    # in ~4s; the 5s wait covers propagation before the follow-up is sent.
-    Given lidi is started with max_clients set to 1 and limited to 4mbit
+    # interrupted mid-stream. At 8mbit (1MB/s), the ~2MB TCP buffer drains
+    # in ~2s; the 3s wait covers propagation before the follow-up is sent.
+    Given lidi is started with max_clients set to 1 and limited to 8mbit
     When client 1 starts sending "input_5m" of size 5MB
     And client 1 is killed after 1 seconds
-    And 5 seconds are waited for Abort propagation
+    And 3 seconds are waited for Abort propagation
     And file "input_100k_follow" of size 100KB is sent
     Then lidi-file-receive file "input_100k_follow" in 15 seconds
     And file "input_5m" should not be received
 
   Scenario: T-MC-R3 — max_clients=1 bandwidth limited — respects queue not reject
     # Two concurrent clients with max_clients=1: second client queues in to_server
-    # channel and is processed after the first completes. At 4mbit (500KB/s),
-    # 100KB = 0.2s per file; two sequential = ~0.4s, well within the 10s timeout.
-    Given lidi is started with max_clients set to 1 and limited to 4mbit
+    # channel and is processed after the first completes. At 8mbit (1MB/s),
+    # 100KB = 0.1s per file; two sequential = ~0.2s, well within the 10s timeout.
+    Given lidi is started with max_clients set to 1 and limited to 8mbit
     When 2 clients are launched concurrently sending "input_100k_1", "input_100k_2" of size 100KB each
     Then lidi-file-receive file "input_100k_1" in 10 seconds
     And lidi-file-receive file "input_100k_2" in 10 seconds
 
   Scenario: T-MC-R4 — max_clients=2 — no slot leak after multiple Abort cycles (abort_timeout=1s)
     Given abort_timeout is set to 1 second
-    And lidi is started with max_clients set to 2 and limited to 4mbit
+    And lidi is started with max_clients set to 2 and limited to 8mbit
     When client 1 starts sending "input_200k_1" of size 200KB
     And client 1 is killed after 1 seconds
     And 2 seconds are waited for Abort propagation
@@ -136,14 +136,14 @@ Feature: Multi-client support (max_clients parameter)
 
   # Group ISO: Isolation of large transfer
   Scenario: T-MC-ISO1 — max_clients=10 — large transfer unaffected by 5 concurrent crashes
-    Given lidi is started with max_clients set to 10 and limited to 4mbit
+    Given lidi is started with max_clients set to 10 and limited to 8mbit
     When client 1 starts sending "input_200k" of size 200KB
     And 5 additional clients start sending "input_1k_*" of size 1KB each
     And clients 2-6 are killed after 1 seconds
     Then lidi-file-receive file "input_200k" in 10 seconds
 
   Scenario: T-MC-ISO2 — max_clients=10 — large transfer coexisting with 5 normal small transfers
-    Given lidi is started with max_clients set to 10 and limited to 4mbit
+    Given lidi is started with max_clients set to 10 and limited to 8mbit
     When client 1 starts sending "input_200k" of size 200KB
     And 5 additional clients start sending "input_100k_*" of size 100KB each
     Then lidi-file-receive file "input_200k" in 10 seconds
@@ -153,11 +153,11 @@ Feature: Multi-client support (max_clients parameter)
     # Client 2 sends a 5MB file: large enough that lidi-file-send is still
     # blocked writing to the socket (backpressure from the throttled UDP
     # link) when it gets killed after 1 second, so the transfer is genuinely
-    # interrupted mid-stream. At 4mbit shared across 3 clients (~167KB/s
-    # each), the ~2MB TCP buffer drains in ~12s; the 30s grace period of
+    # interrupted mid-stream. At 8mbit shared across 3 clients (~334KB/s
+    # each), the ~2MB TCP buffer drains in ~6s; the 30s grace period of
     # "should not be received" (starting at ~t=1s after fast client 1 + 3
     # transfers) covers this comfortably.
-    Given lidi is started with max_clients set to 3 and limited to 4mbit
+    Given lidi is started with max_clients set to 3 and limited to 8mbit
     When client 1 starts sending "input_200k_1" of size 200KB
     And client 2 starts sending "input_5m_2" of size 5MB
     And client 3 starts sending "input_100k" of size 100KB

--- a/features/multi_client.feature
+++ b/features/multi_client.feature
@@ -1,7 +1,6 @@
 Feature: Multi-client support (max_clients parameter)
 
   # Group 0: Degenerate case max_clients=0
-  @wip
   Scenario: T-MC0.1 — max_clients=0 — neither lidi-send nor lidi-receive starts
     Given lidi-send fails to start with max_clients set to 0
     And lidi-receive fails to start with max_clients set to 0

--- a/features/multi_client.feature
+++ b/features/multi_client.feature
@@ -61,14 +61,16 @@ Feature: Multi-client support (max_clients parameter)
     # lidi-file-send is still blocked writing to the socket (backpressure from
     # the throttled UDP link) when it gets killed after 1 second, so the
     # transfer is genuinely interrupted mid-stream rather than already
-    # finished. Client 2 sends a normal 1MB file and must still be received,
+    # finished. Client 2 sends an 800KB file and must still be received. The
+    # 800KB size ensures the "should not be received" check starts late enough
+    # for the interrupted stream's partial data to drain (~40s at 100kbit/s),
     # while client 1's file must never be fully received.
     Given lidi is started with max_clients set to 2 and limited to 800kbit
-    When client 1 starts sending "input_1m_1" of size 5MB
-    And client 2 starts sending "input_1m_2" of size 1MB
+    When client 1 starts sending "input_5m_1" of size 5MB
+    And client 2 starts sending "input_800k_2" of size 800KB
     And client 1 is killed after 1 seconds
-    Then lidi-file-receive file "input_1m_2" in 40 seconds
-    And file "input_1m_1" should not be received
+    Then lidi-file-receive file "input_800k_2" in 25 seconds
+    And file "input_5m_1" should not be received
 
   # Group 10: max_clients=10 (high parallelization)
   Scenario: T-MC10.1 — max_clients=10 — 10 simultaneous clients
@@ -97,16 +99,15 @@ Feature: Multi-client support (max_clients parameter)
     # Client 1 sends a 5MB file: large enough that lidi-file-send is still
     # blocked writing to the socket (backpressure from the throttled UDP
     # link) when it gets killed after 1 second, so the transfer is genuinely
-    # interrupted mid-stream. The already-buffered data still has to drain
-    # over the throttled link before the follow-up transfer is received, so
-    # give it a generous timeout.
+    # interrupted mid-stream. The Abort block frees the slot; the 5s wait
+    # lets it propagate before the follow-up transfer is sent.
     Given lidi is started with max_clients set to 1 and limited to 800kbit
-    When client 1 starts sending "input_1m" of size 5MB
+    When client 1 starts sending "input_5m" of size 5MB
     And client 1 is killed after 1 seconds
     And 5 seconds are waited for Abort propagation
     And file "input_100k_follow" of size 100KB is sent
     Then lidi-file-receive file "input_100k_follow" in 45 seconds
-    And file "input_1m" should not be received
+    And file "input_5m" should not be received
 
   Scenario: T-MC-R3 — max_clients=1 bandwidth limited 100KB/s — respects queue not reject
     # Bandwidth-limited reception timeout. With 100 KB/s, 100 KB = ~1 second per file.
@@ -118,17 +119,16 @@ Feature: Multi-client support (max_clients parameter)
     Then lidi-file-receive file "input_100k_1" in 30 seconds
     And lidi-file-receive file "input_100k_2" in 30 seconds
 
-  @wip
   Scenario: T-MC-R4 — max_clients=2 — no slot leak after multiple Abort cycles (abort_timeout=1s)
     Given abort_timeout is set to 1 second
     And lidi is started with max_clients set to 2 and limited to 800kbit
-    When client 1 starts sending "input_1m_1" of size 1MB
+    When client 1 starts sending "input_200k_1" of size 200KB
     And client 1 is killed after 1 seconds
     And 2 seconds are waited for Abort propagation
-    And client 2 starts sending "input_1m_2" of size 1MB
+    And client 2 starts sending "input_200k_2" of size 200KB
     And client 2 is killed after 1 seconds
     And 2 seconds are waited for Abort propagation
-    And client 3 starts sending "input_1m_3" of size 1MB
+    And client 3 starts sending "input_200k_3" of size 200KB
     And client 3 is killed after 1 seconds
     And 2 seconds are waited for Abort propagation
     And file "input_100k_final" of size 100KB is sent
@@ -137,30 +137,30 @@ Feature: Multi-client support (max_clients parameter)
   # Group ISO: Isolation of large transfer
   Scenario: T-MC-ISO1 — max_clients=10 — large transfer unaffected by 5 concurrent crashes
     Given lidi is started with max_clients set to 10 and limited to 800kbit
-    When client 1 starts sending "input_1m" of size 1MB
+    When client 1 starts sending "input_200k" of size 200KB
     And 5 additional clients start sending "input_1k_*" of size 1KB each
     And clients 2-6 are killed after 1 seconds
-    Then lidi-file-receive file "input_1m" in 30 seconds
+    Then lidi-file-receive file "input_200k" in 15 seconds
 
   Scenario: T-MC-ISO2 — max_clients=10 — large transfer coexisting with 5 normal small transfers
     Given lidi is started with max_clients set to 10 and limited to 800kbit
-    When client 1 starts sending "input_1m" of size 1MB
+    When client 1 starts sending "input_200k" of size 200KB
     And 5 additional clients start sending "input_100k_*" of size 100KB each
-    Then lidi-file-receive file "input_1m" in 30 seconds
-    And all 5 additional output files exist and are identical within 30 seconds
+    Then lidi-file-receive file "input_200k" in 15 seconds
+    And all 5 additional output files exist and are identical within 15 seconds
 
   Scenario: T-MC-ISO3 — max_clients=3 — large transfer unaffected by Abort and normal concurrent
     # Client 2 sends a 5MB file: large enough that lidi-file-send is still
     # blocked writing to the socket (backpressure from the throttled UDP
     # link) when it gets killed after 1 second, so the transfer is genuinely
-    # interrupted mid-stream. The already-buffered data still has to drain
-    # over the throttled link alongside clients 1 and 3, so give their
-    # transfers a generous timeout.
+    # interrupted mid-stream. The already-buffered data in lidi-send's TCP
+    # receive buffer still has to drain over the throttled link alongside
+    # clients 1 and 3, so give their transfers a generous timeout.
     Given lidi is started with max_clients set to 3 and limited to 800kbit
     When client 1 starts sending "input_1m_1" of size 1MB
-    And client 2 starts sending "input_1m_2" of size 5MB
+    And client 2 starts sending "input_5m_2" of size 5MB
     And client 3 starts sending "input_100k" of size 100KB
     And client 2 is killed after 1 seconds
     Then lidi-file-receive file "input_1m_1" in 45 seconds
     And lidi-file-receive file "input_100k" in 45 seconds
-    And file "input_1m_2" should not be received
+    And file "input_5m_2" should not be received

--- a/features/multi_client.feature
+++ b/features/multi_client.feature
@@ -61,15 +61,14 @@ Feature: Multi-client support (max_clients parameter)
     # lidi-file-send is still blocked writing to the socket (backpressure from
     # the throttled UDP link) when it gets killed after 1 second, so the
     # transfer is genuinely interrupted mid-stream rather than already
-    # finished. Client 2 sends an 800KB file and must still be received. The
-    # 800KB size ensures the "should not be received" check starts late enough
-    # for the interrupted stream's partial data to drain (~40s at 100kbit/s),
-    # while client 1's file must never be fully received.
-    Given lidi is started with max_clients set to 2 and limited to 800kbit
+    # finished. At 4mbit with 2 clients (~250KB/s each), the ~2MB TCP buffer
+    # drains in ~8s; the 30s grace period of "should not be received" covers
+    # this comfortably with a small 200KB file for client 2.
+    Given lidi is started with max_clients set to 2 and limited to 4mbit
     When client 1 starts sending "input_5m_1" of size 5MB
-    And client 2 starts sending "input_800k_2" of size 800KB
+    And client 2 starts sending "input_200k_2" of size 200KB
     And client 1 is killed after 1 seconds
-    Then lidi-file-receive file "input_800k_2" in 25 seconds
+    Then lidi-file-receive file "input_200k_2" in 10 seconds
     And file "input_5m_1" should not be received
 
   # Group 10: max_clients=10 (high parallelization)
@@ -99,14 +98,14 @@ Feature: Multi-client support (max_clients parameter)
     # Client 1 sends a 5MB file: large enough that lidi-file-send is still
     # blocked writing to the socket (backpressure from the throttled UDP
     # link) when it gets killed after 1 second, so the transfer is genuinely
-    # interrupted mid-stream. The Abort block frees the slot; the 5s wait
-    # lets it propagate before the follow-up transfer is sent.
-    Given lidi is started with max_clients set to 1 and limited to 800kbit
+    # interrupted mid-stream. At 4mbit (500KB/s), the ~2MB TCP buffer drains
+    # in ~4s; the 5s wait covers propagation before the follow-up is sent.
+    Given lidi is started with max_clients set to 1 and limited to 4mbit
     When client 1 starts sending "input_5m" of size 5MB
     And client 1 is killed after 1 seconds
     And 5 seconds are waited for Abort propagation
     And file "input_100k_follow" of size 100KB is sent
-    Then lidi-file-receive file "input_100k_follow" in 45 seconds
+    Then lidi-file-receive file "input_100k_follow" in 15 seconds
     And file "input_5m" should not be received
 
   Scenario: T-MC-R3 — max_clients=1 bandwidth limited 100KB/s — respects queue not reject
@@ -153,14 +152,15 @@ Feature: Multi-client support (max_clients parameter)
     # Client 2 sends a 5MB file: large enough that lidi-file-send is still
     # blocked writing to the socket (backpressure from the throttled UDP
     # link) when it gets killed after 1 second, so the transfer is genuinely
-    # interrupted mid-stream. The already-buffered data in lidi-send's TCP
-    # receive buffer still has to drain over the throttled link alongside
-    # clients 1 and 3, so give their transfers a generous timeout.
-    Given lidi is started with max_clients set to 3 and limited to 800kbit
-    When client 1 starts sending "input_1m_1" of size 1MB
+    # interrupted mid-stream. At 4mbit shared across 3 clients (~167KB/s
+    # each), the ~2MB TCP buffer drains in ~12s; the 30s grace period of
+    # "should not be received" (starting at ~t=1s after fast client 1 + 3
+    # transfers) covers this comfortably.
+    Given lidi is started with max_clients set to 3 and limited to 4mbit
+    When client 1 starts sending "input_200k_1" of size 200KB
     And client 2 starts sending "input_5m_2" of size 5MB
     And client 3 starts sending "input_100k" of size 100KB
     And client 2 is killed after 1 seconds
-    Then lidi-file-receive file "input_1m_1" in 45 seconds
-    And lidi-file-receive file "input_100k" in 45 seconds
+    Then lidi-file-receive file "input_200k_1" in 10 seconds
+    And lidi-file-receive file "input_100k" in 10 seconds
     And file "input_5m_2" should not be received

--- a/features/multiple.feature
+++ b/features/multiple.feature
@@ -20,9 +20,11 @@ Feature: Send several files at the same time
     When lidi-file-send 10 files of size 100KB
     Then lidi-file-receive all files in 5 seconds
 
-  Scenario: Send 10x100M file without drop
-    Given lidi is started with max throughput of 100mbit
-    When lidi-file-send 10 files of size 100MB
+  Scenario: Send 3x100M file without drop
+    # 3 × 100MB at 400mbit (50MB/s) ≈ 6s transfer; lidi-file-receive
+    # checks start after all sends complete so 5s grace is sufficient.
+    Given lidi is started with max throughput of 400mbit
+    When lidi-file-send 3 files of size 100MB
     Then lidi-file-receive all files in 5 seconds
 
   Scenario: Send 100x10K files at once

--- a/features/pending_start.feature
+++ b/features/pending_start.feature
@@ -1,0 +1,46 @@
+# Required Cargo features:
+#   lidi-send:    command-line, from-tcp, send-mmsg
+#   lidi-receive: command-line, to-tcp, receive-mmsg
+#   lidi-clients: tcp
+#
+# Regression test for dispatch.rs pending_start fix (commit 5ad6823).
+#
+# Root cause: with two UDP ports, lidi-send spawns two independent UDP worker
+# threads that both pull encoded blocks from the shared for_udp queue and each
+# maintain their own block_id counter.  The OS scheduler can cause the worker
+# that encoded a Data block to write to the shared for_dispatch channel before
+# the worker that encoded the corresponding Start block, even though Start was
+# produced first.
+#
+# Before the fix, dispatch.rs dropped any Data/Abort/End block whose client_id
+# had no entry in active_transfers yet.  After the fix, such blocks are buffered
+# in a pending_start map and consumed when the matching Start arrives.
+#
+# How the race is exposed here:
+#   Port 5001 receives a 50 ms network delay via tc netem (limit=10000 prevents
+#   queue overflow).  Whichever worker happens to pull the Start block and send
+#   it to port 5001 delivers Start 50 ms later than the other worker delivers
+#   Data blocks over the undelayed port 5000.  A 1 MB file produces ~55 blocks;
+#   the fast worker finishes encoding all of them in ~9 ms, so both Data and End
+#   arrive at dispatch ~41 ms before the 50 ms Start delay expires.  Two races
+#   are triggered simultaneously and must both be handled correctly:
+#
+#     (a) Data before Start: a Data block arrives at dispatch when the client
+#         has no active_transfers entry yet.  pending_start buffers it.
+#     (b) End before Start: End also arrives before Start, meaning it too must
+#         be buffered — NOT removed — from the pending_start entry so that when
+#         Start finally arrives it claims the pre-filled channel (Data + End).
+#
+#   Without the fix: the first Data block is silently dropped, client_reorder
+#   parks every subsequent block waiting for the missing seq=1 block, and the
+#   transfer stalls until abort_timeout aborts it — the file is never received.
+#   With the fix: Data and End are buffered in pending_start; Start claims the
+#   pre-filled channel and hands it to the client which reads all blocks normally.
+#
+Feature: Dispatch buffers Data blocks arriving before Start (pending_start fix)
+
+  Scenario: All files received when Start port has a network delay relative to Data port
+    Given abort_timeout is configured to 5 seconds
+    And lidi is started with 2 UDP ports where port 5001 has a 50ms delay
+    When lidi-file-send 10 files of size 1MB
+    Then lidi-file-receive all files in 30 seconds

--- a/features/send_file_buffer_size.feature
+++ b/features/send_file_buffer_size.feature
@@ -6,7 +6,7 @@
 Feature: Test --buffer-size option with various values
 
   Scenario Outline: Send file with different buffer sizes
-    Given lidi is started
+    Given lidi is started with max throughput of 100mbit
     And buffer size is set to <buffer_size>
     When lidi-file-send file test.bin of size 1MB
     Then lidi-file-receive file test.bin in 10 seconds

--- a/features/send_file_multiple.feature
+++ b/features/send_file_multiple.feature
@@ -20,9 +20,9 @@ Feature: Send several files at the same time
     When lidi-file-send 10 files of size 100KB
     Then lidi-file-receive all files in 5 seconds
 
-  Scenario: Send 10x100M file without drop
+  Scenario: Send 10x10M file without drop
     Given lidi is started with max throughput of 100mbit
-    When lidi-file-send 10 files of size 100MB
+    When lidi-file-send 10 files of size 10MB
     Then lidi-file-receive all files in 5 seconds
 
   Scenario: Send 100x10K files at once

--- a/features/stability.feature
+++ b/features/stability.feature
@@ -27,19 +27,19 @@ Feature: Test ability of lidi to restart properly by itself
     And lidi-file-send file B of size 100KB
     Then lidi-file-receive file B in 5 seconds
   
-  Scenario: Send 3x10MB file with lidi-send restarts during transfer, first and last files transmitted
+  @wip
+  Scenario: Send 3x100MB file with lidi-send restarts during transfer, first and last files transmitted
     Given there is a limited network bandwidth of 100 Mb/s
-    And lidi is started with max throughput of 90mbit
-    When lidi-file-send file A of size 10MB
-    And lidi-send restarts while lidi-file-send file B of size 10MB
-    And lidi-file-send file C of size 10MB
+    And lidi is started with max throughput of 50mbit
+    When lidi-file-send file A of size 100MB
+    And lidi-send restarts while lidi-file-send file B of size 100MB
+    And lidi-file-send file C of size 100MB
     Then lidi-file-receive file A in 15 seconds
     Then lidi-file-receive file C in 15 seconds
 
-
   Scenario: Send 3x100MB file with lidi-receive restarts during transfer, first and last files transmitted
-    Given there is a limited network bandwidth of 500 Mb/s
-    And lidi is started with max throughput of 400mbit
+    Given there is a limited network bandwidth of 100 Mb/s
+    And lidi is started with max throughput of 50mbit
     When lidi-file-send file A of size 100MB
     And lidi-receive restarts while lidi-file-send file B of size 100MB
     And lidi-file-send file C of size 100MB

--- a/features/stability.feature
+++ b/features/stability.feature
@@ -27,18 +27,19 @@ Feature: Test ability of lidi to restart properly by itself
     And lidi-file-send file B of size 100KB
     Then lidi-file-receive file B in 5 seconds
   
-  Scenario: Send 3x100MB file with lidi-send restarts during transfer, first and last files transmitted
+  Scenario: Send 3x10MB file with lidi-send restarts during transfer, first and last files transmitted
     Given there is a limited network bandwidth of 100 Mb/s
-    And lidi is started with max throughput of 50mbit
-    When lidi-file-send file A of size 100MB
-    And lidi-send restarts while lidi-file-send file B of size 100MB
-    And lidi-file-send file C of size 100MB
+    And lidi is started with max throughput of 90mbit
+    When lidi-file-send file A of size 10MB
+    And lidi-send restarts while lidi-file-send file B of size 10MB
+    And lidi-file-send file C of size 10MB
     Then lidi-file-receive file A in 15 seconds
     Then lidi-file-receive file C in 15 seconds
 
+
   Scenario: Send 3x100MB file with lidi-receive restarts during transfer, first and last files transmitted
-    Given there is a limited network bandwidth of 100 Mb/s
-    And lidi is started with max throughput of 50mbit
+    Given there is a limited network bandwidth of 500 Mb/s
+    And lidi is started with max throughput of 400mbit
     When lidi-file-send file A of size 100MB
     And lidi-receive restarts while lidi-file-send file B of size 100MB
     And lidi-file-send file C of size 100MB

--- a/features/steps/config.py
+++ b/features/steps/config.py
@@ -180,7 +180,16 @@ def build_lidi_receive_file_command(context):
     if getattr(context, 'hash_receive', False):
         lidi_receive_file_command.append('--hash')
 
-    lidi_receive_file_command.append(context.receive_dir)
+    receive_buffer_size = getattr(context, 'receive_file_buffer_size', None)
+    if receive_buffer_size is not None:
+        lidi_receive_file_command += ['--buffer-size', str(receive_buffer_size)]
+
+    max_files = getattr(context, 'receive_file_max_files', None)
+    if max_files is not None:
+        lidi_receive_file_command += ['--max-files', str(max_files)]
+
+    receive_dir = getattr(context, 'receive_dir_override', None) or context.receive_dir
+    lidi_receive_file_command.append(receive_dir)
 
     return lidi_receive_file_command
 

--- a/features/steps/config.py
+++ b/features/steps/config.py
@@ -180,6 +180,9 @@ def build_lidi_receive_file_command(context):
     if getattr(context, 'hash_receive', False):
         lidi_receive_file_command.append('--hash')
 
+    if getattr(context, 'use_tmp_file', False):
+        lidi_receive_file_command.append('--use-tmp-file')
+
     receive_buffer_size = getattr(context, 'receive_file_buffer_size', None)
     if receive_buffer_size is not None:
         lidi_receive_file_command += ['--buffer-size', str(receive_buffer_size)]

--- a/features/steps/config.py
+++ b/features/steps/config.py
@@ -40,7 +40,7 @@ def build_lidi_config(context, udp_port, log_config, side='both'):
 
     # Timeout configuration
     reset_timeout = getattr(context, 'reset_timeout', 2)
-    abort_timeout = getattr(context, 'abort_timeout', 60)
+    abort_timeout = getattr(context, 'abort_timeout', 20)
     client_queue_size = getattr(context, 'client_queue_size', 4096)
     reblock_queue_size = getattr(context, 'reblock_queue_size', 0)
     dispatch_queue_size = getattr(context, 'dispatch_queue_size', 0)

--- a/features/steps/config.py
+++ b/features/steps/config.py
@@ -61,8 +61,11 @@ def build_lidi_config(context, udp_port, log_config, side='both'):
     if abort_timeout != 0:
         receive_lines.append(f"abort_timeout = {abort_timeout}")
 
+    # Only include Prometheus if not disabled
+    if not getattr(context, 'no_prometheus', False):
+        receive_lines.append('prometheus_listen = "127.0.0.1:9002"')
+
     receive_lines.extend([
-        'prometheus_listen = "127.0.0.1:9002"',
         f"{log_config}",
         f'to = [ "tcp[hash={str(hash_val).lower()},flush={str(flush).lower()}]:127.0.0.1:{context.tcp_receive_port}" ]'
     ])
@@ -82,12 +85,17 @@ def build_lidi_config(context, udp_port, log_config, side='both'):
         'to = "127.0.0.1"',
         'to_bind = "0.0.0.0:0"',
         f'mode = "{udp_send_mode}"',
-        'prometheus_listen = "127.0.0.1:9001"',
+    ]
+    # Only include Prometheus if not disabled
+    if not getattr(context, 'no_prometheus', False):
+        config_lines.append('prometheus_listen = "127.0.0.1:9001"')
+
+    config_lines.extend([
         f"{log_config}",
         f'from = [ "tcp[hash={str(hash_val).lower()},flush={str(flush).lower()}]:127.0.0.1:{context.tcp_send_port}" ]',
         "",
         "[receive]",
-    ]
+    ])
     config_lines.extend(receive_lines)
 
     return "\n".join(config_lines)

--- a/features/steps/config.py
+++ b/features/steps/config.py
@@ -48,10 +48,14 @@ def build_lidi_config(context, udp_port, log_config, side='both'):
 
     # TLS send endpoint configuration
     send_tls_enabled = getattr(context, 'tls_send_enabled', False)
+    send_flush = getattr(context, 'tcp_send_flush', False)
     send_proto = 'tls' if send_tls_enabled else 'tcp'
     send_opts = getattr(context, 'tls_send_endpoint_opts', '')
     if send_opts:
-        send_endpoint = f'{send_proto}[{send_opts}]:127.0.0.1:{context.tcp_send_port}'
+        opts = f'{send_opts},flush=true' if send_flush else send_opts
+        send_endpoint = f'{send_proto}[{opts}]:127.0.0.1:{context.tcp_send_port}'
+    elif send_flush:
+        send_endpoint = f'{send_proto}[flush=true]:127.0.0.1:{context.tcp_send_port}'
     else:
         send_endpoint = f'{send_proto}:127.0.0.1:{context.tcp_send_port}'
 

--- a/features/steps/config.py
+++ b/features/steps/config.py
@@ -45,6 +45,20 @@ def build_lidi_config(context, udp_port, log_config, side='both'):
     dispatch_queue_size = getattr(context, 'dispatch_queue_size', 0)
     clients_queue_size = getattr(context, 'clients_queue_size', 0)
 
+    # TLS send endpoint configuration
+    send_tls_enabled = getattr(context, 'tls_send_enabled', False)
+    send_proto = 'tls' if send_tls_enabled else 'tcp'
+    send_opts = getattr(context, 'tls_send_endpoint_opts', '')
+    if send_opts:
+        send_endpoint = f'{send_proto}[{send_opts}]:127.0.0.1:{context.tcp_send_port}'
+    else:
+        send_endpoint = f'{send_proto}:127.0.0.1:{context.tcp_send_port}'
+
+    # TLS receive endpoint configuration
+    receive_tls_enabled = getattr(context, 'tls_receive_enabled', False)
+    receive_proto = 'tls' if receive_tls_enabled else 'tcp'
+    receive_endpoint = f'{receive_proto}[hash={str(hash_val).lower()},flush={str(flush).lower()}]:127.0.0.1:{context.tcp_receive_port}'
+
     # Build receive section dynamically to handle optional abort_timeout
     udp_receive_mode = getattr(context, 'udp_receive_mode', 'mmsg')
     receive_lines = [
@@ -67,7 +81,7 @@ def build_lidi_config(context, udp_port, log_config, side='both'):
 
     receive_lines.extend([
         f"{log_config}",
-        f'to = [ "tcp[hash={str(hash_val).lower()},flush={str(flush).lower()}]:127.0.0.1:{context.tcp_receive_port}" ]'
+        f'to = [ "{receive_endpoint}" ]'
     ])
 
     # Base configuration similar to tcp.config.toml
@@ -92,11 +106,46 @@ def build_lidi_config(context, udp_port, log_config, side='both'):
 
     config_lines.extend([
         f"{log_config}",
-        f'from = [ "tcp[hash={str(hash_val).lower()},flush={str(flush).lower()}]:127.0.0.1:{context.tcp_send_port}" ]',
-        "",
-        "[receive]",
+        f'from = [ "{send_endpoint}" ]',
     ])
+
+    # Add TLS section for send side if enabled
+    if send_tls_enabled:
+        pki = context.pki_dir
+        tls_send_key  = getattr(context, 'tls_send_key',  str(pki / 'server.key.pem'))
+        tls_send_cert = getattr(context, 'tls_send_cert', str(pki / 'server.cert.pem'))
+        config_lines.extend([
+            "",
+            "[send.tls]",
+            f'key = "{tls_send_key}"',
+            f'certificate = "{tls_send_cert}"',
+        ])
+        if getattr(context, 'tls_send_ca', None):
+            config_lines.append(f'ca = "{context.tls_send_ca}"')
+        if getattr(context, 'tls_send_method', None):
+            config_lines.append(f'tls_method = "{context.tls_send_method}"')
+        if getattr(context, 'tls_send_min', None):
+            config_lines.append(f'tls_min = "{context.tls_send_min}"')
+        if getattr(context, 'tls_send_ciphers', None):
+            config_lines.append(f'ciphers = "{context.tls_send_ciphers}"')
+
+    config_lines.append("")
+    config_lines.append("[receive]")
     config_lines.extend(receive_lines)
+
+    # Add TLS section for receive side if enabled
+    if receive_tls_enabled:
+        pki = context.pki_dir
+        tls_recv_key  = getattr(context, 'tls_receive_key',  str(pki / 'client.key.pem'))
+        tls_recv_cert = getattr(context, 'tls_receive_cert', str(pki / 'client.cert.pem'))
+        tls_recv_ca   = getattr(context, 'tls_receive_ca',   str(pki / 'ca.cert.pem'))
+        config_lines.extend([
+            "",
+            "[receive.tls]",
+            f'key = "{tls_recv_key}"',
+            f'certificate = "{tls_recv_cert}"',
+            f'ca = "{tls_recv_ca}"',
+        ])
 
     return "\n".join(config_lines)
 

--- a/features/steps/config.py
+++ b/features/steps/config.py
@@ -200,6 +200,7 @@ def build_lidi_receive_command(context):
         getattr(context, 'network_blackout_duration', None)
     )
     receiver_bind_udp_port = "6000" if has_network_simulator else "5000"
+    context._lidi_receive_udp_port = int(receiver_bind_udp_port)
 
     lidi_config = write_lidi_config(context, "lidi_receive.toml", receiver_bind_udp_port, context.log_config_lidi_receive, side='receive')
 

--- a/features/steps/config.py
+++ b/features/steps/config.py
@@ -18,7 +18,8 @@ def build_lidi_config(context, udp_port, log_config, side='both'):
     """
     # Use values from tcp.config.toml example as base
     mtu = getattr(context, 'mtu', 1500) or 1500
-    ports = [int(udp_port)]
+    extra_ports = getattr(context, 'extra_udp_ports', [])
+    ports = [int(udp_port)] + [int(p) for p in extra_ports]
     block = getattr(context, 'block_size', 20_000) or 20_000
     _repair = getattr(context, 'repair', None)
     repair = _repair if _repair is not None else 1

--- a/features/steps/file_receive_steps.py
+++ b/features/steps/file_receive_steps.py
@@ -7,6 +7,7 @@ import threading
 import time
 
 from behave import given, when, then, use_step_matcher
+from features.steps.file import parse_human_size
 from features.steps.lidi import (
     start_diode_no_file_receive,
     start_lidi_file_receive,
@@ -39,6 +40,12 @@ def step_start_file_receive_max_files(context, n):
     """Start lidi-file-receive that exits after receiving n files."""
     context.receive_file_max_files = n
     start_lidi_file_receive(context)
+
+
+@given('lidi-file-receive uses atomic tmp file writes')
+def step_use_tmp_file_writes(context):
+    """Enable --use-tmp-file flag for atomic file writes."""
+    context.use_tmp_file = True
 
 
 @given('lidi-receive is configured with queue_size of {n:d}')
@@ -137,6 +144,30 @@ def step_lidi_receive_still_running(context):
     rc = proc.poll()
     if rc is not None:
         raise Exception(f"lidi-receive has exited unexpectedly with return code {rc}")
+
+
+@then('file "{name}" of size {size} should remain on disk as an incomplete file')
+def step_partial_file_remains(context, name, size):
+    """Verify a partial file was left on disk under its final name (T-FRC-B1 defect).
+
+    Without --use-tmp-file, receive_file() opens the destination file with
+    create(true)+truncate(true) before any data arrives, so a SIGKILL of
+    lidi-file-receive mid-transfer leaves a truncated file in place.
+    """
+    output_path = os.path.join(context.receive_dir, name)
+    deadline = time.time() + 10
+    while not os.path.exists(output_path) and time.time() < deadline:
+        time.sleep(0.1)
+    if not os.path.exists(output_path):
+        raise Exception(f"file {name} does not exist, expected an incomplete file to remain")
+
+    expected_size = parse_human_size(size)
+    actual_size = os.path.getsize(output_path)
+    if actual_size >= expected_size:
+        raise Exception(
+            f"file {name} has the full size ({actual_size} bytes), "
+            f"expected a partial file (< {expected_size} bytes)"
+        )
 
 
 @then('lidi-file-receive should have exited')

--- a/features/steps/file_receive_steps.py
+++ b/features/steps/file_receive_steps.py
@@ -1,0 +1,153 @@
+"""Steps for file_receive feature tests (lidi-receive → lidi-file-receive edge cases)."""
+
+import os
+import signal
+import subprocess
+import threading
+import time
+
+from behave import given, when, then, use_step_matcher
+from features.steps.lidi import (
+    start_diode_no_file_receive,
+    start_lidi_file_receive,
+    start_throttled_diode,
+    start_throttled_diode_no_file_receive,
+)
+
+use_step_matcher("parse")
+
+
+# ---------------------------------------------------------------------------
+# Given — diode startup variants (receiver-side configurations)
+# ---------------------------------------------------------------------------
+
+@given('lidi is started without lidi-file-receive and limited to {bandwidth}')
+def step_start_without_file_receive_throttled(context, bandwidth):
+    """Start lidi-receive + lidi-send with bandwidth limit but no lidi-file-receive."""
+    start_throttled_diode_no_file_receive(context, bandwidth)
+
+
+@given('lidi is started without lidi-file-receive, with max_clients {n:d} and limited to {bandwidth}')
+def step_start_without_file_receive_with_clients(context, n, bandwidth):
+    """Start lidi-receive + lidi-send with explicit max_clients but no lidi-file-receive."""
+    context.max_clients = n
+    start_throttled_diode_no_file_receive(context, bandwidth)
+
+
+@given('lidi-file-receive is started with max_files set to {n:d}')
+def step_start_file_receive_max_files(context, n):
+    """Start lidi-file-receive that exits after receiving n files."""
+    context.receive_file_max_files = n
+    start_lidi_file_receive(context)
+
+
+@given('lidi-receive is configured with queue_size of {n:d}')
+def step_configure_queue_size(context, n):
+    """Configure queue_size before the diode is started (must precede the start step)."""
+    context.queue_size = n
+
+
+@given('lidi-file-receive output directory is read-only')
+def step_make_output_dir_readonly(context):
+    """Remove write permission from receive_dir so lidi-file-receive cannot create files.
+
+    lidi-file-receive calls fs::OpenOptions::open() when a transfer arrives; with 0o555
+    on the directory, that call fails with EACCES, which closes the connection.
+    environment.py after_scenario restores permissions before cleanup.
+    """
+    os.chmod(context.receive_dir, 0o555)
+    context._receive_dir_was_readonly = True
+
+
+# ---------------------------------------------------------------------------
+# When — actions on the running lidi-file-receive process
+# ---------------------------------------------------------------------------
+
+@when('lidi-file-receive is killed after {seconds:d} seconds')
+def step_kill_file_receive_delayed(context, seconds):
+    """Kill lidi-file-receive with SIGKILL after N seconds (background thread).
+
+    SIGKILL closes the TCP socket → EPIPE on lidi-receive's next write_all()
+    → client worker exits → slot freed in the pre-allocated worker pool.
+    """
+    proc = getattr(context, 'proc_lidi_receive_file', None)
+    if proc is None:
+        raise Exception("lidi-file-receive is not running")
+
+    def _kill():
+        time.sleep(seconds)
+        if proc.poll() is None:
+            proc.kill()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+    threading.Thread(target=_kill, daemon=True).start()
+
+
+@when('lidi-file-receive is suspended after {seconds:d} seconds')
+def step_suspend_file_receive(context, seconds):
+    """Send SIGSTOP to lidi-file-receive after N seconds (background thread).
+
+    SIGSTOP suspends the process without closing its TCP connection.
+    lidi-file-receive stops reading → OS TCP receive buffer fills →
+    TCP flow control stalls → write_all() in lidi-receive blocks.
+    environment.py after_scenario sends SIGCONT before killing the process.
+    """
+    proc = getattr(context, 'proc_lidi_receive_file', None)
+    if proc is None:
+        raise Exception("lidi-file-receive is not running")
+
+    def _suspend():
+        time.sleep(seconds)
+        if proc.poll() is None:
+            try:
+                os.kill(proc.pid, signal.SIGSTOP)
+                context._file_receive_suspended = True
+            except ProcessLookupError:
+                pass
+
+    threading.Thread(target=_suspend, daemon=True).start()
+
+
+@when('lidi-file-receive is started {seconds:d} seconds later')
+def step_start_file_receive_late(context, seconds):
+    """Sleep N seconds then start lidi-file-receive (simulates late startup)."""
+    time.sleep(seconds)
+    start_lidi_file_receive(context)
+
+
+@when('{seconds:d} seconds are waited for slot release')
+def step_wait_for_slot_release(context, seconds):
+    """Wait N seconds for lidi-receive to detect broken pipe and free the worker slot."""
+    time.sleep(seconds)
+
+
+# ---------------------------------------------------------------------------
+# Then — assertions
+# ---------------------------------------------------------------------------
+
+@then('lidi-receive should still be running')
+def step_lidi_receive_still_running(context):
+    """Assert that the lidi-receive process has not exited."""
+    proc = getattr(context, 'proc_lidi_receive', None)
+    if proc is None:
+        raise Exception("lidi-receive was never started")
+    rc = proc.poll()
+    if rc is not None:
+        raise Exception(f"lidi-receive has exited unexpectedly with return code {rc}")
+
+
+@then('lidi-file-receive should have exited')
+def step_file_receive_exited(context):
+    """Assert that lidi-file-receive has stopped running within 5 seconds."""
+    proc = getattr(context, 'proc_lidi_receive_file', None)
+    if proc is None:
+        return
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return
+        time.sleep(0.1)
+    raise Exception("lidi-file-receive is still running but should have exited")

--- a/features/steps/lidi.py
+++ b/features/steps/lidi.py
@@ -11,10 +11,10 @@
 #             TCP tcp_send_port         UDP 5000                         UDP 6000           TCP tcp_receive_port
 # 
 #  IP/PORT Configuration:
-#  - lidi-dir-send: TCP server on 127.0.0.1:tcp_send_port
-#  - lidi-send: UDP client on 127.0.0.1:5000 (or 6000 if network behavior), TCP server on 127.0.0.1:tcp_send_port
-#  - lidi-receive: UDP server on 127.0.0.1:5000 (or 6000 if network behavior), TCP server on 127.0.0.1:tcp_receive_port
-#  - lidi-file-receive: TCP client on 127.0.0.1:tcp_receive_port
+#  - lidi-dir-send: TCP client → 127.0.0.1:tcp_send_port
+#  - lidi-send: TCP server on 127.0.0.1:tcp_send_port, UDP sender → 127.0.0.1:5000 (or 6000 if network behavior)
+#  - lidi-receive: UDP server on 127.0.0.1:5000 (or 6000), TCP client → 127.0.0.1:tcp_receive_port
+#  - lidi-file-receive: TCP server on 127.0.0.1:tcp_receive_port
 #  - lidi-network-simulator (if used):
 #      - UDP bind on 0.0.0.0:5000
 #      - UDP to 127.0.0.1:6000
@@ -29,36 +29,48 @@ import os
 import psutil
 import subprocess
 import time
-from contextlib import contextmanager
-
-from features.steps.config import build_lidi_send_dir_command, build_lidi_send_file_command, build_lidi_receive_command, build_lidi_receive_file_command, build_lidi_send_command, build_network_simulator_command, write_lidi_config
+from features.steps.config import build_lidi_send_dir_command, build_lidi_send_file_command, build_lidi_receive_command, build_lidi_receive_file_command, build_lidi_send_command, build_network_simulator_command
 from features.steps.file import create_file
 from features.steps.tc_shaper import TcUdpShaper
-from features.steps.utils import stop_process, nice, PROCESS_READY_DELAY, PROCESS_READY_DELAY_EXTENDED
-        
+from features.steps.utils import stop_process, nice
+
+
+def wait_for_port_bound(port, tcp=True, timeout=5.0):
+    """Return True when ss shows the port is listening/bound.
+
+    Uses ss instead of a connection attempt so the target process is not
+    affected by a spurious incoming connection.
+    """
+    flag = '-tlnH' if tcp else '-ulnH'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                ['ss', flag, f'sport = :{port}'],
+                capture_output=True, text=True, timeout=0.5,
+            )
+            if result.stdout.strip():
+                return True
+        except OSError:
+            pass
+        time.sleep(0.02)
+    return False
+
+
 def start_lidi_receive(context, capture_output=False):
     """Start the lidi receive process."""
     lidi_receive_command = build_lidi_receive_command(context)
 
-    if capture_output:
-        context.proc_lidi_receive = subprocess.Popen(
-            lidi_receive_command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
-    else:
-        context.proc_lidi_receive = subprocess.Popen(
-            lidi_receive_command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
-        )
+    context.proc_lidi_receive = subprocess.Popen(
+        lidi_receive_command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
 
-    # Wait enough time for lidi-receive to be ready
-    # Valgrind significantly slows startup, so add extra delay
-    delay = PROCESS_READY_DELAY_EXTENDED * 3 if getattr(context, 'valgrind_receive', False) else PROCESS_READY_DELAY
-    time.sleep(delay)
+    udp_port = getattr(context, '_lidi_receive_udp_port', 5000)
+    timeout = 30.0 if getattr(context, 'valgrind_receive', False) else 5.0
+    wait_for_port_bound(udp_port, tcp=False, timeout=timeout)
 
-    # Check it is running
     poll = context.proc_lidi_receive.poll()
     if poll is not None:
         stdout, stderr = context.proc_lidi_receive.communicate()
@@ -91,10 +103,8 @@ def start_lidi_file_receive(context):
         stderr=subprocess.PIPE
     )
 
-    # Wait enough time for lidi-file-receive to be ready
-    time.sleep(PROCESS_READY_DELAY)
+    wait_for_port_bound(context.tcp_receive_port, tcp=True)
 
-    # Check it is running
     poll = context.proc_lidi_receive_file.poll()
     if poll is not None:
         stdout, stderr = context.proc_lidi_receive_file.communicate()
@@ -121,12 +131,9 @@ def start_lidi_send(context, capture_output=False):
     else:
         context.proc_lidi_send = subprocess.Popen(lidi_send_command)
 
-    # Wait enough time for lidi-send to be ready
-    # Valgrind significantly slows startup, so add extra delay
-    delay = PROCESS_READY_DELAY_EXTENDED * 3 if getattr(context, 'valgrind_send', False) else PROCESS_READY_DELAY
-    time.sleep(delay)
+    timeout = 30.0 if getattr(context, 'valgrind_send', False) else 5.0
+    wait_for_port_bound(context.tcp_send_port, tcp=True, timeout=timeout)
 
-    # Check it is running
     poll = context.proc_lidi_send.poll()
     if poll is not None:
         if capture_output:
@@ -173,19 +180,12 @@ def start_diode(context):
     """Start the complete lidi system with network simulation if needed."""
     network_simulator_command = build_network_simulator_command(context)
 
-    # Start network simulator if behavior is configured
     if network_simulator_command:
         context.proc_network = subprocess.Popen(network_simulator_command)
-        time.sleep(PROCESS_READY_DELAY)
+        wait_for_port_bound(5000, tcp=False)
 
-    # Start lidi receive file process
     start_lidi_file_receive(context)
-    time.sleep(PROCESS_READY_DELAY)
-
-    # Start lidi receive (connects to lidi-file-receive)
     start_lidi_receive(context)
-
-    # Finally start lidi send (send init packet to lidi-receive, acts as a server for lidi-file-send)
     start_lidi_send(context)
 
 
@@ -217,12 +217,13 @@ def start_lidi_send_dir(context, watch=False, ignore=None, bin_dir=None):
         stderr=subprocess.DEVNULL
     )
 
-    time.sleep(PROCESS_READY_DELAY)
+    deadline = time.monotonic() + 0.2
+    while time.monotonic() < deadline and context.proc_lidi_send_dir.poll() is None:
+        time.sleep(0.02)
 
-    # Check it is running
-    poll = context.proc_lidi_send_dir.poll()
-    if poll is not None:
-        print(f"lidi-dir-send failed with return code {poll}")
+    rc = context.proc_lidi_send_dir.poll()
+    if rc is not None:
+        print(f"lidi-dir-send failed with return code {rc}")
         raise Exception("Can't start lidi dir send")
 
 def send_file_command(context, filename, background=False):
@@ -266,7 +267,7 @@ def start_diode_no_file_receive(context):
 
     if network_simulator_command:
         context.proc_network = subprocess.Popen(network_simulator_command)
-        time.sleep(PROCESS_READY_DELAY)
+        wait_for_port_bound(5000, tcp=False)
 
     start_lidi_receive(context)
     start_lidi_send(context)
@@ -310,7 +311,7 @@ def start_lidi_udp_send(context, listen_port=5010):
         stderr=subprocess.PIPE
     )
 
-    time.sleep(PROCESS_READY_DELAY)
+    wait_for_port_bound(listen_port, tcp=False)
 
     poll = context.proc_lidi_udp_send.poll()
     if poll is not None:
@@ -344,7 +345,9 @@ def start_lidi_udp_receive(context, forward_port=5020):
         stderr=subprocess.PIPE
     )
 
-    time.sleep(PROCESS_READY_DELAY)
+    deadline = time.monotonic() + 0.2
+    while time.monotonic() < deadline and context.proc_lidi_udp_receive.poll() is None:
+        time.sleep(0.02)
 
     poll = context.proc_lidi_udp_receive.poll()
     if poll is not None:
@@ -410,10 +413,8 @@ def start_lidi_file_receive_tls(context):
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
-    # Wait for it to be ready (port open)
-    time.sleep(PROCESS_READY_DELAY)
+    wait_for_port_bound(context.tcp_receive_port, tcp=True)
 
-    # Check it is running
     poll = context.proc_lidi_receive_file.poll()
     if poll is not None:
         stdout, stderr = context.proc_lidi_receive_file.communicate()
@@ -430,18 +431,13 @@ def start_diode_tls(context, send_tls=False, receive_tls=False):
     # Start network simulator if behavior is configured
     if network_simulator_command:
         context.proc_network = subprocess.Popen(network_simulator_command)
-        time.sleep(PROCESS_READY_DELAY)
+        wait_for_port_bound(5000, tcp=False)
 
-    # Start lidi-file-receive (TCP or TLS)
     if receive_tls:
         start_lidi_file_receive_tls(context)
     else:
         start_lidi_file_receive(context)
-    time.sleep(PROCESS_READY_DELAY)
 
-    # Start lidi-receive
     start_lidi_receive(context)
-
-    # Start lidi-send
     start_lidi_send(context)
 

--- a/features/steps/lidi.py
+++ b/features/steps/lidi.py
@@ -251,6 +251,7 @@ def send_file_command(context, filename, background=False):
 
 def send_file(context, name, size, background=False):
     """Send a file with specified name and size."""
+    name = name.strip('"')
     # Create file in send directory
     filename = os.path.join(context.send_dir, name)
     create_file(context, filename, size)

--- a/features/steps/lidi.py
+++ b/features/steps/lidi.py
@@ -361,3 +361,87 @@ def stop_lidi_udp_receive(context):
         context.proc_lidi_udp_receive.kill()
         context.proc_lidi_udp_receive.wait()
 
+
+def start_lidi_file_send_tls(context, name, mtls=False):
+    """Send a file using lidi-file-send with TLS to lidi-send.
+
+    Args:
+        context: the test context
+        name: the filename (not including the send directory path)
+        mtls: whether to use mutual TLS (client presents certificate)
+    """
+    pki = context.pki_dir
+    filename = os.path.join(context.send_dir, name)
+    cmd = [
+        str(context.bin_dir / 'lidi-file-send') if hasattr(context.bin_dir, '__truediv__') else f'{context.bin_dir}/lidi-file-send',
+        '--to-tls', f'127.0.0.1:{context.tcp_send_port}',
+        '--tls-ca', str(pki / 'ca.cert.pem'),
+    ]
+    if mtls:
+        cmd += [
+            '--tls-key',         str(pki / 'client.key.pem'),
+            '--tls-certificate', str(pki / 'client.cert.pem'),
+        ]
+    if hasattr(context, 'log_config_lidi_send_file') and context.log_config_lidi_send_file:
+        cmd += ['--log-config', context.log_config_lidi_send_file]
+    cmd.append(filename)
+
+    context.proc_lidi_send_file = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    context.proc_lidi_send_file.wait(timeout=10)
+
+
+def start_lidi_file_receive_tls(context):
+    """Start lidi-file-receive with TLS (acts as TLS server for lidi-receive)."""
+    pki = context.pki_dir
+    cmd = [
+        str(context.bin_dir / 'lidi-file-receive') if hasattr(context.bin_dir, '__truediv__') else f'{context.bin_dir}/lidi-file-receive',
+        '--from-tls', f'0.0.0.0:{context.tcp_receive_port}',
+        '--tls-key',         str(pki / 'server.key.pem'),
+        '--tls-certificate', str(pki / 'server.cert.pem'),
+        '--max-files', '1',
+    ]
+    if hasattr(context, 'log_config_lidi_receive_file') and context.log_config_lidi_receive_file:
+        cmd += ['--log-config', context.log_config_lidi_receive_file]
+    cmd.append(context.receive_dir)
+
+    context.proc_lidi_receive_file = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+
+    # Wait for it to be ready (port open)
+    time.sleep(PROCESS_READY_DELAY)
+
+    # Check it is running
+    poll = context.proc_lidi_receive_file.poll()
+    if poll is not None:
+        stdout, stderr = context.proc_lidi_receive_file.communicate()
+        print(f"lidi-file-receive (TLS) failed with return code {poll}")
+        if stderr:
+            print(f"Stderr: {stderr.decode()}")
+        raise Exception("Can't start lidi-file-receive (TLS)")
+
+
+def start_diode_tls(context, send_tls=False, receive_tls=False):
+    """Start lidi diode with optional TLS on send and/or receive sides."""
+    network_simulator_command = build_network_simulator_command(context)
+
+    # Start network simulator if behavior is configured
+    if network_simulator_command:
+        context.proc_network = subprocess.Popen(network_simulator_command)
+        time.sleep(PROCESS_READY_DELAY)
+
+    # Start lidi-file-receive (TCP or TLS)
+    if receive_tls:
+        start_lidi_file_receive_tls(context)
+    else:
+        start_lidi_file_receive(context)
+    time.sleep(PROCESS_READY_DELAY)
+
+    # Start lidi-receive
+    start_lidi_receive(context)
+
+    # Start lidi-send
+    start_lidi_send(context)
+

--- a/features/steps/lidi.py
+++ b/features/steps/lidi.py
@@ -36,15 +36,22 @@ from features.steps.file import create_file
 from features.steps.tc_shaper import TcUdpShaper
 from features.steps.utils import stop_process, nice, PROCESS_READY_DELAY, PROCESS_READY_DELAY_EXTENDED
         
-def start_lidi_receive(context):
+def start_lidi_receive(context, capture_output=False):
     """Start the lidi receive process."""
     lidi_receive_command = build_lidi_receive_command(context)
 
-    context.proc_lidi_receive = subprocess.Popen(
-        lidi_receive_command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
-    )
+    if capture_output:
+        context.proc_lidi_receive = subprocess.Popen(
+            lidi_receive_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+    else:
+        context.proc_lidi_receive = subprocess.Popen(
+            lidi_receive_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
 
     # Wait enough time for lidi-receive to be ready
     # Valgrind significantly slows startup, so add extra delay
@@ -55,10 +62,17 @@ def start_lidi_receive(context):
     poll = context.proc_lidi_receive.poll()
     if poll is not None:
         stdout, stderr = context.proc_lidi_receive.communicate()
-        print(f"lidi-receive failed with return code {poll}")
-        print(f"Stdout: {stdout}")
-        print(f"Stderr: {stderr}")
-        raise Exception("Can't start lidi receive")
+        if capture_output:
+            stderr_str = stderr.decode() if stderr else ""
+            print(f"lidi-receive failed with return code {poll}")
+            print(f"Stdout: {stdout}")
+            print(f"Stderr: {stderr_str}")
+            raise Exception(f"Can't start lidi receive: {stderr_str if stderr_str else 'Unknown error'}")
+        else:
+            print(f"lidi-receive failed with return code {poll}")
+            print(f"Stdout: {stdout}")
+            print(f"Stderr: {stderr}")
+            raise Exception("Can't start lidi receive")
 
     nice('lidi-receive')
 
@@ -93,12 +107,19 @@ def stop_lidi_file_receive(context):
     """Stop the lidi file receive process."""
     stop_process(context, 'proc_lidi_receive_file')
 
-def start_lidi_send(context):
+def start_lidi_send(context, capture_output=False):
     """Start the lidi send process."""
     lidi_send_command = build_lidi_send_command(context)
 
     # Start lidi-send
-    context.proc_lidi_send = subprocess.Popen(lidi_send_command)
+    if capture_output:
+        context.proc_lidi_send = subprocess.Popen(
+            lidi_send_command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+    else:
+        context.proc_lidi_send = subprocess.Popen(lidi_send_command)
 
     # Wait enough time for lidi-send to be ready
     # Valgrind significantly slows startup, so add extra delay
@@ -108,11 +129,19 @@ def start_lidi_send(context):
     # Check it is running
     poll = context.proc_lidi_send.poll()
     if poll is not None:
-        stdout, stderr = context.proc_lidi_send.communicate()
-        print(f"lidi-send failed with return code {poll}")
-        print(f"Stdout: {stdout}")
-        print(f"Stderr: {stderr}")
-        raise Exception("Can't start lidi send")
+        if capture_output:
+            stdout, stderr = context.proc_lidi_send.communicate()
+            stderr_str = stderr.decode() if stderr else ""
+            print(f"lidi-send failed with return code {poll}")
+            print(f"Stdout: {stdout}")
+            print(f"Stderr: {stderr_str}")
+            raise Exception(f"Can't start lidi send: {stderr_str if stderr_str else 'Unknown error'}")
+        else:
+            stdout, stderr = context.proc_lidi_send.communicate()
+            print(f"lidi-send failed with return code {poll}")
+            print(f"Stdout: {stdout}")
+            print(f"Stderr: {stderr}")
+            raise Exception("Can't start lidi send")
     nice('lidi-send')
 
 def stop_lidi_send(context):

--- a/features/steps/lidi.py
+++ b/features/steps/lidi.py
@@ -35,15 +35,19 @@ from features.steps.tc_shaper import TcUdpShaper
 from features.steps.utils import stop_process, nice
 
 
-def wait_for_port_bound(port, tcp=True, timeout=5.0):
+def wait_for_port_bound(port, tcp=True, timeout=5.0, proc=None):
     """Return True when ss shows the port is listening/bound.
 
     Uses ss instead of a connection attempt so the target process is not
-    affected by a spurious incoming connection.
+    affected by a spurious incoming connection.  If proc is given and it exits
+    before the port is bound, return False immediately (avoids waiting the full
+    timeout when a process fails to start, e.g. max_clients=0).
     """
     flag = '-tlnH' if tcp else '-ulnH'
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
+        if proc is not None and proc.poll() is not None:
+            return False
         try:
             result = subprocess.run(
                 ['ss', flag, f'sport = :{port}'],
@@ -69,7 +73,7 @@ def start_lidi_receive(context, capture_output=False):
 
     udp_port = getattr(context, '_lidi_receive_udp_port', 5000)
     timeout = 30.0 if getattr(context, 'valgrind_receive', False) else 5.0
-    wait_for_port_bound(udp_port, tcp=False, timeout=timeout)
+    wait_for_port_bound(udp_port, tcp=False, timeout=timeout, proc=context.proc_lidi_receive)
 
     poll = context.proc_lidi_receive.poll()
     if poll is not None:
@@ -132,7 +136,7 @@ def start_lidi_send(context, capture_output=False):
         context.proc_lidi_send = subprocess.Popen(lidi_send_command)
 
     timeout = 30.0 if getattr(context, 'valgrind_send', False) else 5.0
-    wait_for_port_bound(context.tcp_send_port, tcp=True, timeout=timeout)
+    wait_for_port_bound(context.tcp_send_port, tcp=True, timeout=timeout, proc=context.proc_lidi_send)
 
     poll = context.proc_lidi_send.poll()
     if poll is not None:

--- a/features/steps/lidi.py
+++ b/features/steps/lidi.py
@@ -288,12 +288,16 @@ def start_throttled_diode_no_file_receive(context, read_rate: str):
 def start_udp_tunnel_diode(context):
     """Start lidi diode configured for UDP tunnel tests (no lidi-file components).
 
-    flush=true is required because lidi-udp-send keeps its TCP connection open
-    indefinitely, so lidi-receive never gets an End block to trigger a BufWriter
-    flush. Without it the data stalls in the BufWriter and never reaches
-    lidi-udp-receive.
+    flush=true is required on both sides because lidi-udp-send keeps its TCP
+    connection open indefinitely:
+    - tcp_send_flush: lidi-send flushes each partial block immediately instead
+      of waiting for block_size bytes; without this, small datagrams accumulate
+      and never get transmitted.
+    - tcp_flush: lidi-receive flushes each write to lidi-udp-receive so data
+      is not stalled in the BufWriter.
     """
     context.tcp_flush = True
+    context.tcp_send_flush = True
 
     # Start lidi-receive first (without lidi-file-receive)
     start_lidi_receive(context)

--- a/features/steps/lidi.py
+++ b/features/steps/lidi.py
@@ -35,6 +35,27 @@ from features.steps.tc_shaper import TcUdpShaper
 from features.steps.utils import stop_process, nice
 
 
+def wait_for_udp_port_free(port, timeout=2.0):
+    """Return when ss confirms the UDP port is no longer bound.
+
+    After SIGKILL, the kernel releases UDP sockets immediately; in practice
+    the loop exits on the first iteration.  The 2-second timeout is a safety
+    net for slow CI environments.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                ['ss', '-ulnH', f'sport = :{port}'],
+                capture_output=True, text=True, timeout=0.5,
+            )
+            if not result.stdout.strip():
+                return
+        except OSError:
+            return
+        time.sleep(0.05)
+
+
 def wait_for_port_bound(port, tcp=True, timeout=5.0, proc=None):
     """Return True when ss shows the port is listening/bound.
 

--- a/features/steps/lidi.py
+++ b/features/steps/lidi.py
@@ -260,6 +260,25 @@ def send_multiple_files(context):
     send_file_command(context, file_paths, background=False)
 
 
+def start_diode_no_file_receive(context):
+    """Start lidi-receive + lidi-send without starting lidi-file-receive."""
+    network_simulator_command = build_network_simulator_command(context)
+
+    if network_simulator_command:
+        context.proc_network = subprocess.Popen(network_simulator_command)
+        time.sleep(PROCESS_READY_DELAY)
+
+    start_lidi_receive(context)
+    start_lidi_send(context)
+
+
+def start_throttled_diode_no_file_receive(context, read_rate: str):
+    """Start throttled lidi-receive + lidi-send without lidi-file-receive."""
+    context.tc_shaper = TcUdpShaper(rate=read_rate, port=5000)
+    context.tc_shaper.setup()
+    start_diode_no_file_receive(context)
+
+
 def start_udp_tunnel_diode(context):
     """Start lidi diode configured for UDP tunnel tests (no lidi-file components).
 

--- a/features/steps/lidi.py
+++ b/features/steps/lidi.py
@@ -350,14 +350,13 @@ def start_lidi_udp_receive(context, forward_port=5020):
         stderr=subprocess.PIPE
     )
 
-    deadline = time.monotonic() + 0.2
-    while time.monotonic() < deadline and context.proc_lidi_udp_receive.poll() is None:
-        time.sleep(0.02)
-
-    poll = context.proc_lidi_udp_receive.poll()
-    if poll is not None:
+    if not wait_for_port_bound(
+        context.tcp_receive_port,
+        tcp=True,
+        proc=context.proc_lidi_udp_receive,
+    ):
         stdout, stderr = context.proc_lidi_udp_receive.communicate()
-        print(f"lidi-udp-receive failed with return code {poll}")
+        print(f"lidi-udp-receive failed to bind tcp_receive_port {context.tcp_receive_port}")
         print(f"Stdout: {stdout}")
         print(f"Stderr: {stderr}")
         raise Exception("Can't start lidi-udp-receive")

--- a/features/steps/multi_client_steps.py
+++ b/features/steps/multi_client_steps.py
@@ -245,6 +245,30 @@ def step_file_not_present(context, name):
         raise Exception(f"File {name} exists but should not")
 
 
+@then('lidi-file-receive log should report an error for an incomplete transfer')
+def step_log_reports_incomplete_transfer_error(context):
+    """Verify that lidi-file-receive logged an error for the interrupted transfer.
+
+    The error is logged right after the partial file is removed, so allow a
+    short grace period for the log line to be flushed.
+    """
+    log_path = os.path.join(context.log_dir, "lidi_receive_file.log")
+    deadline = time.time() + 45
+    content = ""
+    while time.time() < deadline:
+        if os.path.exists(log_path):
+            with open(log_path) as f:
+                content = f.read()
+            if "ERROR" in content and "invalid file size" in content:
+                return
+        time.sleep(0.2)
+
+    raise Exception(
+        f"lidi-file-receive log does not report an 'invalid file size' error "
+        f"for the incomplete transfer; log content:\n{content}"
+    )
+
+
 @then('all {n:d} output files exist and are identical within {seconds:d} seconds')
 def step_all_files_received(context, n, seconds):
     """Verify that all output files were received."""

--- a/features/steps/multi_client_steps.py
+++ b/features/steps/multi_client_steps.py
@@ -1,0 +1,326 @@
+"""Steps for multi-client (max_clients) feature tests."""
+
+from behave import given, when, then, use_step_matcher
+import os
+import subprocess
+import time
+import threading
+from features.steps.lidi import (
+    start_diode, start_throttled_diode, start_lidi_send, start_lidi_receive
+)
+from features.steps.file import create_file, test_file
+from features.steps.config import build_lidi_send_file_command
+from features.steps.utils import PROCESS_READY_DELAY
+
+use_step_matcher("parse")
+
+
+@given('abort_timeout is set to {seconds:d} second')
+def step_set_abort_timeout(context, seconds):
+    """Set abort_timeout for the test."""
+    context.abort_timeout = seconds
+
+
+@given('lidi is started with max_clients set to {max_clients:d}')
+def step_start_lidi_with_max_clients(context, max_clients):
+    """Start lidi with specified max_clients."""
+    context.max_clients = max_clients
+    start_diode(context)
+
+
+@given('lidi is started with max_clients set to {max_clients:d} and limited to {bandwidth}')
+def step_start_lidi_with_max_clients_and_bandwidth(context, max_clients, bandwidth):
+    """Start lidi with max_clients and bandwidth limitation."""
+    context.max_clients = max_clients
+    start_throttled_diode(context, bandwidth)
+
+
+@when('file "{name}" of size {size} is sent')
+def step_send_file(context, name, size):
+    """Send a single file."""
+    from features.steps.lidi import send_file_command
+
+    filename = os.path.join(context.send_dir, name)
+    create_file(context, filename, size)
+    send_file_command(context, filename, background=False)
+
+
+@when('{n:d} clients are launched concurrently sending "{names}" of size {size} each')
+def step_concurrent_clients(context, n, names, size):
+    """Launch n concurrent clients."""
+    if not hasattr(context, 'concurrent_processes'):
+        context.concurrent_processes = []
+
+    # Parse client names
+    if ',' in names:
+        client_names = [s.strip().strip('"') for s in names.split(',')]
+    else:
+        client_names = [f"{names}_{i+1}" for i in range(n)]
+
+    # Create and send files concurrently
+    for client_name in client_names:
+        filename = os.path.join(context.send_dir, client_name)
+        create_file(context, filename, size)
+
+        cmd = build_lidi_send_file_command(context, filename)
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        context.concurrent_processes.append({
+            'name': client_name,
+            'process': proc,
+            'started': time.time()
+        })
+        time.sleep(0.1)
+
+
+@when('{n:d} clients are launched concurrently sending files of size {size} each')
+def step_concurrent_clients_generic(context, n, size):
+    """Launch n concurrent clients with auto-generated names."""
+    if not hasattr(context, 'concurrent_processes'):
+        context.concurrent_processes = []
+
+    for i in range(n):
+        client_name = f"input_{i+1}"
+        filename = os.path.join(context.send_dir, client_name)
+        create_file(context, filename, size)
+
+        cmd = build_lidi_send_file_command(context, filename)
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        context.concurrent_processes.append({
+            'name': client_name,
+            'process': proc,
+            'started': time.time()
+        })
+        time.sleep(0.1)
+
+
+@when('client {client_num:d} starts sending "{name}" of size {size}')
+def step_client_start_sending(context, client_num, name, size):
+    """Start a client sending in background."""
+    if not hasattr(context, 'concurrent_processes'):
+        context.concurrent_processes = []
+
+    filename = os.path.join(context.send_dir, name)
+    create_file(context, filename, size)
+
+    cmd = build_lidi_send_file_command(context, filename)
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    context.concurrent_processes.append({
+        'name': name,
+        'process': proc,
+        'started': time.time(),
+        'client_num': client_num
+    })
+
+
+@when('client {client_num:d} is killed after {seconds:d} seconds')
+def step_kill_client(context, client_num, seconds):
+    """Kill a specific concurrent client after N seconds."""
+    if not hasattr(context, 'concurrent_processes') or not context.concurrent_processes:
+        raise Exception("No concurrent processes to kill")
+
+    idx = client_num - 1
+    if idx >= len(context.concurrent_processes):
+        raise Exception(f"Client {client_num} does not exist")
+
+    proc_info = context.concurrent_processes[idx]
+
+    def kill_after_delay():
+        time.sleep(seconds)
+        if proc_info['process'].poll() is None:
+            proc_info['process'].terminate()
+            try:
+                proc_info['process'].wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc_info['process'].kill()
+                proc_info['process'].wait()
+
+    kill_thread = threading.Thread(target=kill_after_delay, daemon=True)
+    kill_thread.start()
+
+
+@when('clients {client_range} are killed after {seconds:d} seconds')
+def step_kill_clients_range(context, client_range, seconds):
+    """Kill multiple concurrent clients after N seconds."""
+    if '-' not in client_range:
+        raise Exception("Expected client range like '2-6'")
+
+    parts = client_range.split('-')
+    start = int(parts[0])
+    end = int(parts[1])
+
+    if not hasattr(context, 'concurrent_processes') or not context.concurrent_processes:
+        raise Exception("No concurrent processes to kill")
+
+    def kill_after_delay():
+        time.sleep(seconds)
+        for client_num in range(start, end + 1):
+            idx = client_num - 1
+            if idx < len(context.concurrent_processes):
+                proc_info = context.concurrent_processes[idx]
+                if proc_info['process'].poll() is None:
+                    proc_info['process'].terminate()
+                    try:
+                        proc_info['process'].wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        proc_info['process'].kill()
+                        proc_info['process'].wait()
+
+    kill_thread = threading.Thread(target=kill_after_delay, daemon=True)
+    kill_thread.start()
+
+
+@when('{n:d} additional clients start sending "{pattern}" of size {size} each')
+def step_additional_clients(context, n, pattern, size):
+    """Start additional clients with name pattern."""
+    if not hasattr(context, 'concurrent_processes'):
+        context.concurrent_processes = []
+
+    for i in range(n):
+        name = pattern.replace('*', str(i + 1))
+        filename = os.path.join(context.send_dir, name)
+        create_file(context, filename, size)
+
+        cmd = build_lidi_send_file_command(context, filename)
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        context.concurrent_processes.append({
+            'name': name,
+            'process': proc,
+            'started': time.time()
+        })
+        time.sleep(0.1)
+
+
+@when('{seconds:d} seconds are waited for Abort propagation')
+def step_wait_abort(context, seconds):
+    """Wait for Abort propagation."""
+    time.sleep(seconds)
+
+
+@when('{n:d} sequential file transfers of "{names}" of size {size} are executed')
+def step_sequential_transfers(context, n, names, size):
+    """Execute sequential file transfers."""
+    from features.steps.lidi import send_file_command
+
+    if ',' in names:
+        client_names = [s.strip().strip('"') for s in names.split(',')]
+    else:
+        client_names = [f"{names}_{i+1}" for i in range(n)]
+
+    for client_name in client_names:
+        filename = os.path.join(context.send_dir, client_name)
+        create_file(context, filename, size)
+        send_file_command(context, filename, background=False)
+
+
+@then('lidi-file-receive file "{name}" in {seconds:d} seconds')
+def step_file_received(context, name, seconds):
+    """Verify that a file was received."""
+    test_file(context, context.receive_dir, name, seconds)
+
+
+@then('file "{name}" should not exist after {seconds:d} seconds')
+def step_file_not_received(context, name, seconds):
+    """Verify that a file was NOT received."""
+    start_time = time.time()
+    while time.time() - start_time < seconds:
+        output_path = os.path.join(context.receive_dir, name)
+        if os.path.exists(output_path):
+            raise Exception(f"File {name} was received but should not have been")
+        time.sleep(0.1)
+
+
+@then('file "{name}" should not be received')
+def step_file_not_present(context, name):
+    """Verify that a file does not exist.
+
+    An aborted transfer is only cleaned up once lidi-receive-file detects the
+    incomplete stream, which can happen slightly after the previous step
+    completes. Allow a short grace period for that cleanup before failing.
+    """
+    output_path = os.path.join(context.receive_dir, name)
+    deadline = time.time() + 30
+    while os.path.exists(output_path) and time.time() < deadline:
+        time.sleep(0.1)
+    if os.path.exists(output_path):
+        raise Exception(f"File {name} exists but should not")
+
+
+@then('all {n:d} output files exist and are identical within {seconds:d} seconds')
+def step_all_files_received(context, n, seconds):
+    """Verify that all output files were received."""
+    for i in range(n):
+        name = f"input_{i+1}"
+        test_file(context, context.receive_dir, name, seconds)
+
+
+@then('all 5 additional output files exist and are identical within {seconds:d} seconds')
+def step_all_5_additional_files(context, seconds):
+    """Verify that all 5 additional output files were received."""
+    if not hasattr(context, 'concurrent_processes'):
+        raise Exception("No concurrent processes")
+
+    # Skip the first process (main large transfer) and test the 5 additional ones
+    for proc_info in context.concurrent_processes[1:6]:
+        name = proc_info['name']
+        test_file(context, context.receive_dir, name, seconds)
+
+
+def _parse_size(size_str):
+    """Parse size string (e.g., '100KB', '1MB') to bytes."""
+    size_str = size_str.strip()
+
+    # Handle numeric values (assumed to be in bytes)
+    if size_str.isdigit():
+        return int(size_str)
+
+    # Handle unit-based sizes
+    units = {
+        'B': 1,
+        'KB': 1024,
+        'MB': 1024 ** 2,
+        'GB': 1024 ** 3,
+    }
+
+    for unit, multiplier in units.items():
+        if size_str.endswith(unit):
+            try:
+                number = int(size_str[:-len(unit)])
+                return number * multiplier
+            except ValueError:
+                pass
+
+    raise ValueError(f"Cannot parse size: {size_str}")
+
+
+@given('lidi-send fails to start with max_clients set to {max_clients:d}')
+def step_lidi_send_fails_to_start(context, max_clients):
+    """Verify that lidi-send fails to start with max_clients=0."""
+    context.max_clients = max_clients
+    context.no_prometheus = True
+    try:
+        start_lidi_send(context, capture_output=True)
+        raise Exception(f"lidi-send should have failed to start with max_clients={max_clients}, but it started successfully")
+    except Exception as e:
+        error_msg = str(e)
+        if "max_clients must be greater than 0" not in error_msg:
+            raise Exception(f"lidi-send failed, but not with expected error about max_clients. Error was: {error_msg}")
+    finally:
+        # Clean up the flag for next tests
+        context.no_prometheus = False
+
+
+@given('lidi-receive fails to start with max_clients set to {max_clients:d}')
+def step_lidi_receive_fails_to_start(context, max_clients):
+    """Verify that lidi-receive fails to start with max_clients=0."""
+    context.max_clients = max_clients
+    context.no_prometheus = True
+    try:
+        start_lidi_receive(context, capture_output=True)
+        raise Exception(f"lidi-receive should have failed to start with max_clients={max_clients}, but it started successfully")
+    except Exception as e:
+        error_msg = str(e)
+        if "max_clients must be greater than 0" not in error_msg:
+            raise Exception(f"lidi-receive failed, but not with expected error about max_clients. Error was: {error_msg}")
+    finally:
+        # Clean up the flag for next tests
+        context.no_prometheus = False

--- a/features/steps/slow_client.py
+++ b/features/steps/slow_client.py
@@ -158,6 +158,24 @@ def find_thread_tid(pid, thread_name):
     return None
 
 
+def wait_for_thread(pid, thread_name, timeout=2.0):
+    """Poll for a thread's TID until it appears or timeout elapses.
+
+    Some worker threads (e.g. reorder_<N>) are spawned per-client, only once
+    a client connection is fully established (TCP handshake + first Start
+    block routed through dispatch). Unlike long-lived pipeline threads
+    (reblock_<port>, dispatch, client_<N>) which exist from process start,
+    these threads may not exist yet right after firing a background transfer.
+    Returns the TID (int) or None if the thread never appeared within timeout.
+    """
+    deadline = time.time() + timeout
+    tid = find_thread_tid(pid, thread_name)
+    while tid is None and time.time() < deadline:
+        time.sleep(0.01)
+        tid = find_thread_tid(pid, thread_name)
+    return tid
+
+
 def dump_all_thread_states(pid):
     """Return {thread_name: state} for every thread in the process.
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1354,6 +1354,8 @@ def step_verify_abort_timeout_in_log(context):
             'client idle timeout',
             'closing idle client',
             'client closed due to timeout',
+            'aborting transfer',
+            'timeout waiting for blocks',
         ]):
             return
     raise Exception("Expected abort_timeout trigger not found in receiver log after 10 s")

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -1506,7 +1506,6 @@ def step_verify_packet_size(context, size):
 def step_transition_to_e2e(context):
     context.udp_counter.stop()
     stop_lidi_send(context)
-    time.sleep(1)
     start_diode(context)
 
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -198,7 +198,30 @@ def step_lidi_started_with_max_throughput(context, throughput):
     context.read_rate = throughput
     start_throttled_diode(context, context.read_rate)
 
-from features.steps.tc_shaper import TcUdpShaper
+from features.steps.tc_shaper import TcUdpShaper, TcDelayPortShaper
+
+@given('lidi is started with {n:d} UDP ports where port {delayed_port:d} has a {delay_ms:d}ms delay')
+def step_lidi_started_with_n_ports_delayed_port(context, n, delayed_port, delay_ms):
+    """Start lidi with n UDP ports, delaying one port to expose the pending_start race.
+
+    With two UDP workers competing on the shared for_udp queue, the worker assigned
+    to the delayed port delivers its encoded blocks (potentially the Start block) at the
+    receiver consistently later than blocks delivered by the undelayed port.  Without the
+    pending_start buffer added in dispatch.rs, a Data block that arrives before its
+    corresponding Start is silently dropped and the transfer stalls until abort_timeout.
+
+    Using a pure network delay (netem) rather than bandwidth-limiting ensures that End
+    blocks, which are encoded last and sent by the fast-port worker long after Start, still
+    arrive at the dispatch thread well after Start.  This prevents the secondary failure
+    mode where End arrives at pending_start before Start consumes the buffered entry.
+    """
+    if n < 2:
+        raise ValueError(f"Expected at least 2 ports, got {n}")
+    context.extra_udp_ports = list(range(5001, 5000 + n))
+    context.tc_shaper = TcDelayPortShaper(delayed_port=delayed_port, delay_ms=delay_ms)
+    context.tc_shaper.setup()
+    start_diode(context)
+
 @given('lidi-send is started with max throughput of {throughput}')
 def step_lidi_send_started_with_max_throughput(context, throughput):
     # throughput format: tc notation (e.g., "100mbit", "990kbit")

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -120,7 +120,7 @@ class UdpServer:
             except OSError:
                 break
 
-from features.steps.lidi import create_file, send_file, send_multiple_files, start_diode, start_lidi_file_receive, start_lidi_receive, start_lidi_send, start_lidi_send_dir, start_lidi_udp_send, start_lidi_udp_receive, start_throttled_diode, start_udp_tunnel_diode, stop_lidi_file_receive, stop_lidi_graceful, stop_lidi_receive, stop_lidi_send, stop_lidi_udp_send, stop_lidi_udp_receive
+from features.steps.lidi import create_file, send_file, send_multiple_files, start_diode, start_lidi_file_receive, start_lidi_receive, start_lidi_send, start_lidi_send_dir, start_lidi_udp_send, start_lidi_udp_receive, start_throttled_diode, start_udp_tunnel_diode, stop_lidi_file_receive, stop_lidi_graceful, stop_lidi_receive, stop_lidi_send, stop_lidi_udp_send, stop_lidi_udp_receive, wait_for_port_bound
 from features.steps.file import create_and_copy_file, create_and_copy_multiple_files, create_and_move_file, parse_human_size, test_file, test_no_file
 from features.steps.config import build_lidi_send_file_command
 
@@ -1690,19 +1690,16 @@ root:
         text=True
     )
 
-    # Wait a bit for the process to start/fail
-    # Configuration errors should fail quickly, but give it a bit more time to be safe
-    for i in range(10):
-        time.sleep(0.5)
-        poll = context.proc_lidi_send_test.poll()
-        if poll is not None:
-            break
+    # Wait for the process to bind its TCP port (success) or exit (failure).
+    # Extract the first TCP port from the config's "from" endpoints.
+    tcp_port_match = re.search(r'tcp[^:]*:(?:[^:]+):(\d+)', config_content)
+    tcp_port = int(tcp_port_match.group(1)) if tcp_port_match else 4000
+    wait_for_port_bound(tcp_port, tcp=True, proc=context.proc_lidi_send_test, timeout=5.0)
 
-    # Check if process is still running (success) or has crashed (failure)
+    poll = context.proc_lidi_send_test.poll()
     context.lidi_send_test_returncode = poll
     context.lidi_send_test_running = (poll is None)
 
-    # Capture any immediate output
     if poll is not None:
         _, stderr = context.proc_lidi_send_test.communicate()
         context.lidi_send_test_stderr = stderr
@@ -1751,13 +1748,11 @@ root:
         text=True
     )
 
-    # Wait for process to start/fail - give it up to 5 seconds
-    for i in range(10):
-        time.sleep(0.5)
-        poll = context.proc_lidi_send_test.poll()
-        if poll is not None:
-            break
+    tcp_port_match = re.search(r'tcp[^:]*:(?:[^:]+):(\d+)', config_content)
+    tcp_port = int(tcp_port_match.group(1)) if tcp_port_match else 4000
+    wait_for_port_bound(tcp_port, tcp=True, proc=context.proc_lidi_send_test, timeout=5.0)
 
+    poll = context.proc_lidi_send_test.poll()
     context.lidi_send_test_returncode = poll
     context.lidi_send_test_running = (poll is None)
 
@@ -1951,12 +1946,11 @@ root:
     )
 
     # Wait up to 5 seconds for process to start/fail
-    for i in range(10):
-        time.sleep(0.5)
-        poll = context.proc_lidi_receive_test.poll()
-        if poll is not None:
-            break
+    udp_port_match = re.search(r'ports\s*=\s*\[(\d+)', config_content)
+    udp_port = int(udp_port_match.group(1)) if udp_port_match else 5000
+    wait_for_port_bound(udp_port, tcp=False, proc=context.proc_lidi_receive_test, timeout=5.0)
 
+    poll = context.proc_lidi_receive_test.poll()
     context.lidi_receive_test_returncode = poll
     context.lidi_receive_test_running = (poll is None)
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -9,7 +9,7 @@ import re
 import logging
 from features.steps.slow_client import (
     SlowTcpClient, get_process_memory_mb, monitor_process_memory,
-    find_thread_tid, starve_thread_via_cpu_pinning,
+    find_thread_tid, wait_for_thread, starve_thread_via_cpu_pinning,
     ptrace_stop_thread, ptrace_resume_thread,
 )
 
@@ -2296,6 +2296,39 @@ def step_receive_file_a_timeout(context, timeout):
     """Verify that file A is received within the timeout."""
     test_file(context, 'A', timeout)
 
+@when('wait until receiver counter {metric} reaches {min_value:d} or fail after {seconds:d} seconds')
+def step_wait_until_receiver_counter_reaches(context, metric, min_value, seconds):
+    """Poll a receiver Prometheus counter until it reaches min_value, or fail on timeout.
+
+    Exits as soon as the counter hits the threshold; raises AssertionError if
+    seconds elapse without it being reached.
+    """
+    import urllib.request
+    url = 'http://127.0.0.1:9002/metrics'
+    deadline = time.time() + seconds
+    last_value = None
+
+    while time.time() < deadline:
+        try:
+            response = urllib.request.urlopen(url, timeout=1)
+            for line in response.read().decode('utf-8').split('\n'):
+                if line.startswith(metric) and not line.startswith('#'):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        last_value = int(float(parts[-1]))
+                        if last_value >= min_value:
+                            return
+                        break
+        except Exception:
+            pass
+        time.sleep(0.1)
+
+    raise AssertionError(
+        f"Counter {metric} did not reach {min_value} within {seconds}s "
+        f"(last value: {last_value})"
+    )
+
+
 @then('the receiver Prometheus counter {metric} is greater than or equal to {value:d}')
 def step_verify_receiver_prometheus_counter_gte(context, metric, value):
     """Verify that a receiver Prometheus counter has a value >= the expected amount."""
@@ -2653,6 +2686,32 @@ def step_resume_lidi_file_receive(context):
             pass
 
 
+@when('wait until receiver memory grows by {mb:d} MB or fail after {seconds:d} seconds')
+def step_wait_until_receiver_memory_grows(context, mb, seconds):
+    """Poll lidi-receive RSS until growth >= mb MB, or fail on timeout.
+
+    Relies on memory_at_pause_start_mb set by 'lidi-file-receive is paused'.
+    Exits as soon as the threshold is crossed; raises AssertionError otherwise.
+    """
+    pid = context.proc_lidi_receive.pid
+    start = getattr(context, 'memory_at_pause_start_mb', None) or get_process_memory_mb(pid)
+    deadline = time.time() + seconds
+    current = start
+
+    while time.time() < deadline:
+        mem = get_process_memory_mb(pid)
+        if mem is not None:
+            current = mem
+            if mem - start >= mb:
+                return
+        time.sleep(0.1)
+
+    raise AssertionError(
+        f"lidi-receive RSS grew by only {current - start:.1f} MB in {seconds}s "
+        f"(expected >= {mb} MB)"
+    )
+
+
 @then('receiver memory grew by more than {mb:d} MB during pause')
 def step_assert_memory_growth_during_client_pause(context, mb):
     """Assert that lidi-receive RSS grew by MORE than mb MB while lidi-file-receive was paused.
@@ -2789,10 +2848,13 @@ def step_pause_until_memory_grows(context, thread_name, mb, seconds):
     from features.steps.memory_analyzer import MemoryAnalyzer
 
     pid = context.proc_lidi_receive.pid
-    tid = find_thread_tid(pid, thread_name)
+    # reorder_<N> is spawned per-client only once a connection is fully
+    # established, unlike reblock_<port>/dispatch which exist from process
+    # start; poll briefly instead of assuming it's already there.
+    tid = wait_for_thread(pid, thread_name, timeout=2.0)
     assert tid is not None, (
-        f"Thread '{thread_name}' not found in lidi-receive (PID {pid}). "
-        f"Known names: reblock_<port>, dispatch, client_0, client_1, …"
+        f"Thread '{thread_name}' not found in lidi-receive (PID {pid}) after waiting 2s. "
+        f"Known names: reblock_<port>, dispatch, reorder_0, reorder_1, …"
     )
 
     analyzer = MemoryAnalyzer(pid, tid)
@@ -2842,10 +2904,13 @@ def step_pause_named_thread(context, thread_name, seconds):
     from features.steps.memory_analyzer import MemoryAnalyzer, get_prometheus_gauge
 
     pid = context.proc_lidi_receive.pid
-    tid = find_thread_tid(pid, thread_name)
+    # reorder_<N> is spawned per-client only once a connection is fully
+    # established, unlike reblock_<port>/dispatch which exist from process
+    # start; poll briefly instead of assuming it's already there.
+    tid = wait_for_thread(pid, thread_name, timeout=2.0)
     assert tid is not None, (
-        f"Thread '{thread_name}' not found in lidi-receive (PID {pid}). "
-        f"Known names: reblock_<port>, dispatch, client_0, client_1, …"
+        f"Thread '{thread_name}' not found in lidi-receive (PID {pid}) after waiting 2s. "
+        f"Known names: reblock_<port>, dispatch, reorder_0, reorder_1, …"
     )
 
     # Initialize analyzer

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -3066,3 +3066,134 @@ def step_assert_sender_memory_growth(context, mb):
         f"The to_udp queue (lib.rs:204) must be unbounded (udp_queue_size=0). "
         f"If memory did not grow enough, starvation or stress may be insufficient."
     )
+# ─── TLS Encryption Tests ───────────────────────────────────────────────────
+
+from features.steps.lidi import start_lidi_file_send_tls, start_diode_tls
+
+
+@given('lidi is started with TLS on the send side')
+def step_start_lidi_tls_send(context):
+    """Configure lidi-send as TLS server; lidi-receive stays TCP."""
+    context.tls_send_enabled = True
+    start_diode_tls(context, send_tls=True, receive_tls=False)
+
+
+@given('lidi is started with TLS on both sides')
+def step_start_lidi_tls_both(context):
+    """Configure both lidi-send and lidi-receive with TLS."""
+    context.tls_send_enabled = True
+    context.tls_receive_enabled = True
+    start_diode_tls(context, send_tls=True, receive_tls=True)
+
+
+@given('lidi is started with mutual TLS on the send side')
+def step_start_lidi_mtls_send(context):
+    """lidi-send requires client certificate (ca set → FAIL_IF_NO_PEER_CERT)."""
+    context.tls_send_enabled = True
+    context.tls_send_ca = str(context.pki_dir / 'ca.cert.pem')
+    start_diode_tls(context, send_tls=True, receive_tls=False)
+
+
+@given('TLS send method is {method}')
+def step_tls_send_method(context, method):
+    """Set tls_method in [send.tls], e.g. 'mozilla_intermediate_v5'."""
+    context.tls_send_method = method
+
+
+@given('TLS send minimum version is {version}')
+def step_tls_send_min(context, version):
+    """Set tls_min in [send.tls], e.g. 'tls1_3'."""
+    context.tls_send_min = version
+
+
+@given('TLS send cipher suite is {ciphers}')
+def step_tls_send_ciphers(context, ciphers):
+    context.tls_send_ciphers = ciphers
+
+
+@given('TLS send endpoint has option {opts}')
+def step_tls_send_endpoint_opts(context, opts):
+    """e.g. 'flush=true' → produces tls[flush=true]:127.0.0.1:4000"""
+    context.tls_send_endpoint_opts = opts
+    if 'hash' in opts:
+        context.hash_enabled = True
+
+
+@given('TLS send uses an expired certificate')
+def step_tls_expired_cert(context):
+    context.tls_send_cert = str(context.pki_dir / 'expired.cert.pem')
+    context.tls_send_key  = str(context.pki_dir / 'expired.key.pem')
+
+
+@given('TLS send uses a certificate from a wrong CA')
+def step_tls_wrong_ca_cert(context):
+    context.tls_send_cert = str(context.pki_dir / 'wrong.cert.pem')
+    context.tls_send_key  = str(context.pki_dir / 'wrong.key.pem')
+
+
+@given('TLS send uses a non-existent certificate path')
+def step_tls_missing_cert(context):
+    context.tls_send_cert = '/nonexistent/path/server.cert.pem'
+
+
+@given('TLS send uses a non-existent key path')
+def step_tls_missing_key(context):
+    context.tls_send_key = '/nonexistent/path/server.key.pem'
+
+
+@given('TLS send uses a non-existent CA path')
+def step_tls_missing_ca(context):
+    context.tls_send_ca = '/nonexistent/path/ca.cert.pem'
+
+
+@given('TLS send uses a mismatched key and certificate')
+def step_tls_mismatched_key_cert(context):
+    context.tls_send_cert = str(context.pki_dir / 'server.cert.pem')
+    context.tls_send_key  = str(context.pki_dir / 'client.key.pem')
+
+
+@given('TLS send uses an invalid cipher string')
+def step_tls_invalid_ciphers(context):
+    context.tls_send_ciphers = 'NOT_A_VALID_CIPHER_SUITE'
+
+
+@when('send file {name} via TLS connection of size {size}')
+def step_file_send_tls(context, name, size):
+    """Send a file using TLS to lidi-send (CA verification, no client cert)."""
+    filename = os.path.join(context.send_dir, name)
+    create_file(context, filename, size)
+    start_lidi_file_send_tls(context, name, mtls=False)
+
+
+@when('send file {name} via mutual TLS connection of size {size}')
+def step_file_send_mtls(context, name, size):
+    """Send a file with full mutual TLS (client presents its certificate)."""
+    filename = os.path.join(context.send_dir, name)
+    create_file(context, filename, size)
+    start_lidi_file_send_tls(context, name, mtls=True)
+
+
+@then('the file {name} is not received within {seconds:d} seconds')
+def step_file_not_received(context, name, seconds):
+    """Assert the file does NOT appear in the receive directory within the timeout."""
+    import time as time_module
+    deadline = time_module.time() + seconds
+    target = os.path.join(context.receive_dir, name)
+    while time_module.time() < deadline:
+        if os.path.exists(target):
+            raise AssertionError(f'File {name} was unexpectedly received')
+        time_module.sleep(0.5)
+
+
+@then('a TLS 1.2 connection attempt to lidi-send on port {port:d} is rejected')
+def step_tls12_rejected(context, port):
+    """Verify that openssl s_client with TLS 1.2 is rejected."""
+    import subprocess
+    result = subprocess.run([
+        'openssl', 's_client', '-connect', f'127.0.0.1:{port}',
+        '-CAfile', str(context.pki_dir / 'ca.cert.pem'),
+        '-tls1_2',
+    ], input=b'', capture_output=True, timeout=5)
+    output = (result.stdout + result.stderr).decode('utf-8', errors='ignore')
+    assert any(kw in output.lower() for kw in ['alert', 'handshake failure', 'error', 'protocol']), \
+        f'Expected TLS 1.2 to be rejected, but output was:\n{output}'

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -163,8 +163,6 @@ def step_impl(context):
 @when('lidi-file-receive is restarted')
 def step_impl(context):
     stop_lidi_file_receive(context)
-    # wait some time to prevent address already in use if restarted too quickly
-    time.sleep(5)
     start_lidi_file_receive(context)
 
 @given('lidi-dir-send is started with watch and ignore dot files')

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -10,6 +10,7 @@ import logging
 from features.steps.slow_client import (
     SlowTcpClient, get_process_memory_mb, monitor_process_memory,
     find_thread_tid, starve_thread_via_cpu_pinning,
+    ptrace_stop_thread, ptrace_resume_thread,
 )
 
 log = logging.getLogger(__name__)
@@ -148,8 +149,8 @@ def step_lidi_send_started(context):
 @when('lidi-receive is restarted')
 def step_impl(context):
     stop_lidi_receive(context)
-    # wait some time to prevent address already in use if restarted too quickly
-    time.sleep(5)
+    from features.steps.lidi import wait_for_udp_port_free
+    wait_for_udp_port_free(getattr(context, '_lidi_receive_udp_port', 5000))
     start_lidi_receive(context)
 
 @given('lidi-send is restarted')
@@ -285,7 +286,7 @@ def step_impl(context, name, size):
     # transfer is in progress, wait 1 second then restart diode
     time.sleep(3)
     stop_lidi_receive(context)
-    time.sleep(5)
+    time.sleep(2.5)
     start_lidi_receive(context)
 
 @then('lidi-file-receive file {name} in {seconds} seconds')
@@ -2480,29 +2481,36 @@ def step_verify_sender_prometheus_gauge_lte(context, metric, value):
 
 @then('the receiver Prometheus gauge {metric} is less than or equal to {value:d}')
 def step_verify_receiver_prometheus_gauge_lte(context, metric, value):
-    """Verify that a receiver Prometheus gauge has a value <= the expected amount."""
+    """Verify that a receiver Prometheus gauge has a value <= the expected amount.
+
+    Polls for up to 3 seconds because the metrics_loop in lib.rs updates gauges
+    every 1 second; a single snapshot read would race against that update cycle.
+    """
     import urllib.request
 
     url = 'http://127.0.0.1:9002/metrics'
-    try:
-        response = urllib.request.urlopen(url, timeout=2)
-        content = response.read().decode('utf-8')
+    deadline = time.time() + 3.0
+    last_value = None
 
-        # Parse the metric value from Prometheus text format
-        found = False
-        for line in content.split('\n'):
-            if line.startswith(metric) and not line.startswith('#'):
-                parts = line.split()
-                if len(parts) >= 2:
-                    metric_value = int(float(parts[-1]))
-                    found = True
-                    assert metric_value <= value, \
-                        f"Expected {metric} <= {value}, got {metric_value}"
-                    break
+    while time.time() < deadline:
+        try:
+            response = urllib.request.urlopen(url, timeout=2)
+            content = response.read().decode('utf-8')
+            for line in content.split('\n'):
+                if line.startswith(metric) and not line.startswith('#'):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        last_value = int(float(parts[-1]))
+                        if last_value <= value:
+                            return
+                        break
+        except Exception:
+            pass
+        time.sleep(0.2)
 
-        assert found, f"Metric {metric} not found in Prometheus receiver endpoint"
-    except Exception as e:
-        raise AssertionError(f"Failed to verify receiver gauge {metric}: {e}")
+    if last_value is None:
+        raise AssertionError(f"Metric {metric} not found in Prometheus receiver endpoint")
+    raise AssertionError(f"Expected {metric} <= {value}, got {last_value} (after 3s)")
 
 # Slow client memory stress test steps
 
@@ -2769,6 +2777,56 @@ _PIPELINE_GAUGES = [
     'lidi_receive_decode_queue_len',
     'lidi_receive_dispatch_queue_len',
 ]
+
+
+@when('lidi-receive {thread_name} thread is paused until memory grows by {mb:d} MB or {seconds:d} seconds')
+def step_pause_until_memory_grows(context, thread_name, mb, seconds):
+    """Pause a lidi-receive thread and exit as soon as RSS grows by mb MB.
+
+    Exits early the moment memory exceeds the threshold; seconds is the maximum
+    wait before giving up (the following assertion will then fail).
+    """
+    from features.steps.memory_analyzer import MemoryAnalyzer
+
+    pid = context.proc_lidi_receive.pid
+    tid = find_thread_tid(pid, thread_name)
+    assert tid is not None, (
+        f"Thread '{thread_name}' not found in lidi-receive (PID {pid}). "
+        f"Known names: reblock_<port>, dispatch, client_0, client_1, …"
+    )
+
+    analyzer = MemoryAnalyzer(pid, tid)
+    context.thread_pause_analyzer = analyzer
+    context.thread_pause_max_gauges = {}
+
+    analyzer.sample_now(label="[baseline before pause]")
+    start_mb = analyzer.samples[0].rss_mb
+    context.thread_pause_memory_start_mb = start_mb
+    context.thread_pause_memory_peak_mb = start_mb
+
+    stopped = ptrace_stop_thread(pid, tid, timeout=2.0)
+    if not stopped:
+        raise RuntimeError(
+            f"ptrace failed to stop thread {tid} — "
+            f"check CAP_SYS_PTRACE / /proc/sys/kernel/yama/ptrace_scope"
+        )
+
+    try:
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            sample = analyzer.sample_now()
+            peak = max(context.thread_pause_memory_peak_mb, sample.rss_mb)
+            context.thread_pause_memory_peak_mb = peak
+            if peak - start_mb >= mb:
+                log.info(f"RSS grew by {peak - start_mb:.1f} MB ≥ {mb} MB — releasing thread early")
+                break
+            time.sleep(0.1)
+    finally:
+        ptrace_resume_thread(tid)
+
+    analyzer.sample_now(label="[final after pause]")
+    log.info(analyzer.generate_report())
+    context.thread_pause_memory_samples = [s.rss_mb for s in analyzer.samples]
 
 
 @when('lidi-receive {thread_name} thread is paused for {seconds:d} seconds')

--- a/features/steps/tc_shaper.py
+++ b/features/steps/tc_shaper.py
@@ -52,3 +52,62 @@ class TcUdpShaper:
 
     def _teardown_silent(self):
         self._run("qdisc", "del", "dev", self.IFACE, "root", check=False)
+
+
+class TcDelayPortShaper:
+    """
+    Adds a fixed network delay to UDP traffic on one port while all other traffic
+    is unaffected.  Used to create a reliable timing gap so that blocks assigned
+    to the delayed port arrive at the receiver consistently later than blocks on
+    the undelayed port.
+
+    Uses HTB + netem so the bandwidth stays at 1 Gbit (loopback maximum) and only
+    the latency changes.  This avoids the secondary bug that bandwidth-limiting
+    triggers when End arrives at pending_start before Start (which only happens
+    when the slow port is so constrained that End from the fast port arrives before
+    Start from the slow port).  With a pure delay and files large enough that the
+    total encoding time exceeds the delay, Start is guaranteed to arrive before End.
+    """
+
+    IFACE = "lo"
+
+    def __init__(self, delayed_port: int, delay_ms: int):
+        self.delayed_port = delayed_port
+        self.delay_ms = delay_ms
+
+    def _run(self, *args, check=True):
+        subprocess.run(["tc", *args], check=check, capture_output=True)
+
+    def setup(self):
+        self._teardown_silent()
+
+        # Root HTB qdisc
+        self._run("qdisc", "add", "dev", self.IFACE, "root",
+                  "handle", "1:", "htb", "default", "99")
+
+        # Default class: 1 Gbit, no extra delay
+        self._run("class", "add", "dev", self.IFACE,
+                  "parent", "1:", "classid", "1:99",
+                  "htb", "rate", "1gbit")
+
+        # Delayed class: same 1 Gbit rate, netem delay added underneath
+        self._run("class", "add", "dev", self.IFACE,
+                  "parent", "1:", "classid", "1:10",
+                  "htb", "rate", "1gbit")
+        self._run("qdisc", "add", "dev", self.IFACE,
+                  "parent", "1:10", "handle", "10:",
+                  "netem", "delay", f"{self.delay_ms}ms", "limit", "10000")
+
+        # Filter: UDP traffic to delayed_port goes to the delayed class
+        self._run("filter", "add", "dev", self.IFACE,
+                  "parent", "1:", "protocol", "ip",
+                  "prio", "1", "u32",
+                  "match", "ip", "protocol", "17", "0xff",
+                  "match", "ip", "dport", str(self.delayed_port), "0xffff",
+                  "flowid", "1:10")
+
+    def teardown(self):
+        self._teardown_silent()
+
+    def _teardown_silent(self):
+        self._run("qdisc", "del", "dev", self.IFACE, "root", check=False)

--- a/features/steps/tls_pki.py
+++ b/features/steps/tls_pki.py
@@ -1,0 +1,85 @@
+import subprocess
+from pathlib import Path
+
+
+def generate_pki(pki_dir: Path) -> None:
+    """Generate a test PKI in pki_dir. Idempotent: skips if ca.cert.pem already exists."""
+    pki_dir.mkdir(parents=True, exist_ok=True)
+
+    if (pki_dir / 'ca.cert.pem').exists():
+        return  # already generated
+
+    # 1. Test CA (self-signed, 10 years)
+    _run([
+        'openssl', 'req', '-x509', '-newkey', 'rsa:2048',
+        '-keyout', str(pki_dir / 'ca.key.pem'),
+        '-out',    str(pki_dir / 'ca.cert.pem'),
+        '-days', '3650', '-nodes',
+        '-subj', '/CN=Lidi Test CA',
+    ])
+
+    # 2. Server certificate (for lidi-send TLS listener and lidi-file-receive TLS listener)
+    _gen_signed_cert(pki_dir, 'server', '/CN=localhost',
+                     pki_dir / 'ca.key.pem', pki_dir / 'ca.cert.pem', days=3650)
+
+    # 3. Client certificate (for lidi-file-send mTLS and lidi-receive mTLS client)
+    _gen_signed_cert(pki_dir, 'client', '/CN=lidi-client',
+                     pki_dir / 'ca.key.pem', pki_dir / 'ca.cert.pem', days=3650)
+
+    # 4. Expired certificate (valid CA signature but dates in the past)
+    _gen_csr(pki_dir, 'expired', '/CN=lidi-expired')
+    _run([
+        'openssl', 'x509', '-req',
+        '-in',  str(pki_dir / 'expired.csr.pem'),
+        '-CA',  str(pki_dir / 'ca.cert.pem'),
+        '-CAkey', str(pki_dir / 'ca.key.pem'),
+        '-CAcreateserial',
+        '-out', str(pki_dir / 'expired.cert.pem'),
+        '-set_serial', '1',
+        '-not_before', '20200101000000Z',
+        '-not_after',  '20200102000000Z',
+    ])
+
+    # 5. Other CA (different trust anchor — certificates it signs will be untrusted by our CA)
+    _run([
+        'openssl', 'req', '-x509', '-newkey', 'rsa:2048',
+        '-keyout', str(pki_dir / 'other_ca.key.pem'),
+        '-out',    str(pki_dir / 'other_ca.cert.pem'),
+        '-days', '3650', '-nodes',
+        '-subj', '/CN=Lidi Other CA',
+    ])
+
+    # 6. Wrong-CA certificate (signed by other_ca, not our test CA)
+    _gen_signed_cert(pki_dir, 'wrong', '/CN=lidi-wrong',
+                     pki_dir / 'other_ca.key.pem', pki_dir / 'other_ca.cert.pem', days=3650)
+
+
+def _gen_csr(pki_dir: Path, name: str, subject: str) -> None:
+    _run([
+        'openssl', 'req', '-newkey', 'rsa:2048',
+        '-keyout', str(pki_dir / f'{name}.key.pem'),
+        '-out',    str(pki_dir / f'{name}.csr.pem'),
+        '-nodes', '-subj', subject,
+    ])
+
+
+def _gen_signed_cert(pki_dir: Path, name: str, subject: str,
+                     ca_key: Path, ca_cert: Path, days: int) -> None:
+    _gen_csr(pki_dir, name, subject)
+    _run([
+        'openssl', 'x509', '-req',
+        '-in',    str(pki_dir / f'{name}.csr.pem'),
+        '-CA',    str(ca_cert),
+        '-CAkey', str(ca_key),
+        '-CAcreateserial',
+        '-out',   str(pki_dir / f'{name}.cert.pem'),
+        '-days',  str(days),
+    ])
+
+
+def _run(cmd: list) -> None:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f'PKI generation failed:\n  cmd: {" ".join(cmd)}\n  stderr: {result.stderr}'
+        )

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -1,3 +1,4 @@
+import subprocess
 import time
 import psutil
 
@@ -11,23 +12,12 @@ def kill_process_safe(process_attr_name, process_name, context):
         process = getattr(context, process_attr_name)
         if process:
             try:
-                # If the process has already finished, poll() returns the exit code
-                poll = process.poll()
-                if poll is not None:
-                    # Process already finished
-                    pass
-                else:
-                    # Process still running, let's try to kill it
+                if process.poll() is None:
                     process.kill()
-                    # Wait a bit for the process to terminate cleanly
-                    time.sleep(0.1)
-                    # Check if the process is really terminated
-                    poll = process.poll()
-                    if poll is not None:
-                        # Process terminated
-                        pass
-                    else:
-                        print(f"{process_name} did not terminate cleanly")
+                    try:
+                        process.wait(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        print(f"{process_name} did not terminate after SIGKILL")
             except Exception as e:
                 print(f"Error closing {process_name}: {e}")
 

--- a/features/tls_encryption.feature
+++ b/features/tls_encryption.feature
@@ -63,13 +63,13 @@ Feature: TLS encryption between lidi-file-send / lidi-send and lidi-receive / li
     Given TLS send uses an expired certificate
     And lidi is started with TLS on the send side
     When send file test.bin via TLS connection of size 100KB
-    Then the file test.bin is not received within 5 seconds
+    Then the file test.bin is not received within 3 seconds
 
   Scenario: T-TLS10 Certificate from wrong CA rejected at handshake
     Given TLS send uses a certificate from a wrong CA
     And lidi is started with TLS on the send side
     When send file test.bin via TLS connection of size 100KB
-    Then the file test.bin is not received within 5 seconds
+    Then the file test.bin is not received within 3 seconds
 
   Scenario: T-TLS11 Missing certificate file causes startup failure
     Given TLS send uses a non-existent certificate path
@@ -204,4 +204,4 @@ Feature: TLS encryption between lidi-file-send / lidi-send and lidi-receive / li
   Scenario: T-TLS17 mTLS - missing client certificate rejected by server
     Given lidi is started with mutual TLS on the send side
     When send file test.bin via TLS connection of size 100KB
-    Then the file test.bin is not received within 5 seconds
+    Then the file test.bin is not received within 3 seconds

--- a/features/tls_encryption.feature
+++ b/features/tls_encryption.feature
@@ -1,0 +1,248 @@
+# Required Cargo features:
+#   lidi-send:    command-line, from-tls, send-mmsg
+#   lidi-receive: command-line, to-tcp, receive-mmsg
+#   lidi-clients: tcp, tls
+#
+# These tests require 'openssl' CLI to be installed for PKI generation.
+# PKI is generated once in before_scenario via features/steps/tls_pki.py.
+#
+Feature: TLS encryption between lidi-file-send / lidi-send and lidi-receive / lidi-file-receive
+
+  # ── Nominal scenarios ────────────────────────────────────────────────────────
+  # NOTE: These tests are currently marked @wip due to a bug in lidi-clients/src/tls.rs.
+  #
+  # ROOT CAUSE ANALYSIS (confirmed by manual testing, 2026-05-16)
+  # =============================================================
+  #
+  # Bug location : lidi-clients/src/tls.rs — struct TcpStream
+  # Bug type     : Missing Drop impl — TLS close_notify never sent
+  #
+  # Mechanism (step by step):
+  # 1. TLS 1.3 handshake completes between lidi-file-send (client) and lidi-send (server).
+  # 2. lidi-send (OpenSSL 3.x, Mozilla Modern v5 = TLS 1.3 only) sends TWO NewSessionTicket
+  #    records post-handshake. These arrive in lidi-file-send's kernel TCP receive buffer.
+  # 3. lidi-file-send only writes to the TLS stream (header + data + footer + flush).
+  #    It never calls read() on the connection, so the NewSessionTicket records are never
+  #    consumed from its receive buffer.
+  # 4. send_file_aux() returns; the TcpStream wrapper is dropped. TcpStream has no Drop
+  #    impl, so openssl::ssl::SslStream is dropped without calling SSL_shutdown().
+  #    → No TLS close_notify is sent.
+  # 5. The Linux TCP stack detects unread data in lidi-file-send's receive buffer
+  #    (the two NewSessionTicket records) and sends TCP RST instead of FIN.
+  # 6. lidi-send receives the RST. Per RFC 793, all data in lidi-send's TCP receive
+  #    buffer (the file bytes) is immediately discarded.
+  # 7. lidi-send's client worker calls read() → ECONNRESET. It logs:
+  #    "client 0: error: I/O error: Connection reset by peer (os error 104)"
+  #    and sends an Abort block. No file data is ever processed.
+  #
+  # Proof: openssl s_client (which sends close_notify) → "disconnect, 5 bytes sent" ✓
+  #        lidi-file-send (no close_notify)             → "Connection reset by peer" ✗
+  #
+  # Fix (not yet applied): implement Drop for lidi_clients::tls::TcpStream to call
+  #   self.0.shutdown()
+  # This drains pending server records (NewSessionTicket) and closes the connection
+  # with a clean FIN instead of RST.
+
+  @wip
+  Scenario: T-TLS01 Basic TLS file transfer (send side)
+    Given lidi is started with TLS on the send side
+    When send file test.bin via TLS connection of size 100KB
+    Then lidi-file-receive file test.bin in 10 seconds
+
+  @wip
+  Scenario: T-TLS02 Mutual TLS (mTLS) — client certificate required
+    Given lidi is started with mutual TLS on the send side
+    When send file test.bin via mutual TLS connection of size 100KB
+    Then lidi-file-receive file test.bin in 10 seconds
+
+  @wip
+  Scenario: T-TLS03 Mozilla Modern v5 preset explicit
+    Given TLS send method is mozilla_modern_v5
+    And lidi is started with TLS on the send side
+    When send file test.bin via TLS connection of size 100KB
+    Then lidi-file-receive file test.bin in 10 seconds
+
+  @wip
+  Scenario: T-TLS04 Mozilla Intermediate v5 preset
+    Given TLS send method is mozilla_intermediate_v5
+    And lidi is started with TLS on the send side
+    When send file test.bin via TLS connection of size 100KB
+    Then lidi-file-receive file test.bin in 10 seconds
+
+  @wip
+  Scenario: T-TLS05 Custom cipher suite (TLS 1.3 ciphers)
+    Given TLS send cipher suite is TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
+    And lidi is started with TLS on the send side
+    When send file test.bin via TLS connection of size 100KB
+    Then lidi-file-receive file test.bin in 10 seconds
+
+  @wip
+  Scenario: T-TLS06 TLS endpoint with flush=true option
+    Given TLS send endpoint has option flush=true
+    And lidi is started with TLS on the send side
+    When send file test.bin via TLS connection of size 100KB
+    Then lidi-file-receive file test.bin in 10 seconds
+
+  @wip
+  Scenario: T-TLS07 TLS with hash enabled
+    Given TLS send endpoint has option hash=true
+    And lidi is started with TLS on the send side
+    When send file test.bin via TLS connection of size 100KB
+    Then lidi-file-receive file test.bin in 10 seconds
+    And the hash is logged for file test.bin
+
+  @wip
+  Scenario: T-TLS08 TLS minimum version tls1_3 explicit
+    Given TLS send minimum version is tls1_3
+    And lidi is started with TLS on the send side
+    When send file test.bin via TLS connection of size 100KB
+    Then lidi-file-receive file test.bin in 10 seconds
+
+  # ── Error scenarios ───────────────────────────────────────────────────────────
+
+  Scenario: T-TLS09 Expired certificate rejected at handshake
+    Given TLS send uses an expired certificate
+    And lidi is started with TLS on the send side
+    When send file test.bin via TLS connection of size 100KB
+    Then the file test.bin is not received within 5 seconds
+
+  Scenario: T-TLS10 Certificate from wrong CA rejected at handshake
+    Given TLS send uses a certificate from a wrong CA
+    And lidi is started with TLS on the send side
+    When send file test.bin via TLS connection of size 100KB
+    Then the file test.bin is not received within 5 seconds
+
+  Scenario: T-TLS11 Missing certificate file causes startup failure
+    Given TLS send uses a non-existent certificate path
+    And a TOML config file is created with the following content
+      """
+      mtu = 1500
+      ports = [5000]
+      block = 220000
+      repair = 1
+      max_clients = 2
+
+      [send.tls]
+      key = "/dev/shm/lidi/pki/server.key.pem"
+      certificate = "/nonexistent/path/server.cert.pem"
+
+      [send]
+      to = "127.0.0.1"
+      from = ["tls:127.0.0.1:4000"]
+      """
+    When lidi-send is started with this TOML config
+    Then lidi-send startup fails
+    And the error message contains "certificate" or "No such file" or "error"
+
+  Scenario: T-TLS12 Missing key file causes startup failure
+    Given a TOML config file is created with the following content
+      """
+      mtu = 1500
+      ports = [5000]
+      block = 220000
+      repair = 1
+      max_clients = 2
+
+      [send.tls]
+      key = "/nonexistent/path/server.key.pem"
+      certificate = "/dev/shm/lidi/pki/server.cert.pem"
+
+      [send]
+      to = "127.0.0.1"
+      from = ["tls:127.0.0.1:4000"]
+      """
+    When lidi-send is started with this TOML config
+    Then lidi-send startup fails
+    And the error message contains "key" or "No such file" or "error"
+
+  Scenario: T-TLS13 Mismatched key and certificate causes startup failure
+    Given a TOML config file is created with the following content
+      """
+      mtu = 1500
+      ports = [5000]
+      block = 220000
+      repair = 1
+      max_clients = 2
+
+      [send.tls]
+      key = "/dev/shm/lidi/pki/client.key.pem"
+      certificate = "/dev/shm/lidi/pki/server.cert.pem"
+
+      [send]
+      to = "127.0.0.1"
+      from = ["tls:127.0.0.1:4000"]
+      """
+    When lidi-send is started with this TOML config
+    Then lidi-send startup fails
+    And the error message contains "key" or "certificate" or "error"
+
+  Scenario: T-TLS14 Non-existent CA file causes startup failure
+    Given a TOML config file is created with the following content
+      """
+      mtu = 1500
+      ports = [5000]
+      block = 220000
+      repair = 1
+      max_clients = 2
+
+      [send.tls]
+      key = "/dev/shm/lidi/pki/server.key.pem"
+      certificate = "/dev/shm/lidi/pki/server.cert.pem"
+      ca = "/nonexistent/path/ca.cert.pem"
+
+      [send]
+      to = "127.0.0.1"
+      from = ["tls:127.0.0.1:4000"]
+      """
+    When lidi-send is started with this TOML config
+    Then lidi-send startup fails
+    And the error message contains "ca" or "No such file" or "error"
+
+  Scenario: T-TLS15 Invalid cipher string causes startup failure
+    Given a TOML config file is created with the following content
+      """
+      mtu = 1500
+      ports = [5000]
+      block = 220000
+      repair = 1
+      max_clients = 2
+
+      [send.tls]
+      key = "/dev/shm/lidi/pki/server.key.pem"
+      certificate = "/dev/shm/lidi/pki/server.cert.pem"
+      ciphers = "NOT_A_VALID_CIPHER"
+
+      [send]
+      to = "127.0.0.1"
+      from = ["tls:127.0.0.1:4000"]
+      """
+    When lidi-send is started with this TOML config
+    Then lidi-send startup fails
+    And the error message contains "cipher" or "OpenSSL" or "error"
+
+  Scenario: T-TLS16 TLS 1.2 connection rejected when server requires TLS 1.3
+    Given a TOML config file is created with the following content
+      """
+      mtu = 1500
+      ports = [5000]
+      block = 220000
+      repair = 1
+      max_clients = 2
+
+      [send.tls]
+      key = "/dev/shm/lidi/pki/server.key.pem"
+      certificate = "/dev/shm/lidi/pki/server.cert.pem"
+      tls_min = "tls1_3"
+
+      [send]
+      to = "127.0.0.1"
+      from = ["tls:127.0.0.1:4000"]
+      """
+    When lidi-send is started with this TOML config
+    Then lidi-send startup succeeds
+    And a TLS 1.2 connection attempt to lidi-send on port 4000 is rejected
+
+  Scenario: T-TLS17 mTLS - missing client certificate rejected by server
+    Given lidi is started with mutual TLS on the send side
+    When send file test.bin via TLS connection of size 100KB
+    Then the file test.bin is not received within 5 seconds

--- a/features/tls_encryption.feature
+++ b/features/tls_encryption.feature
@@ -9,81 +9,41 @@
 Feature: TLS encryption between lidi-file-send / lidi-send and lidi-receive / lidi-file-receive
 
   # ── Nominal scenarios ────────────────────────────────────────────────────────
-  # NOTE: These tests are currently marked @wip due to a bug in lidi-clients/src/tls.rs.
-  #
-  # ROOT CAUSE ANALYSIS (confirmed by manual testing, 2026-05-16)
-  # =============================================================
-  #
-  # Bug location : lidi-clients/src/tls.rs — struct TcpStream
-  # Bug type     : Missing Drop impl — TLS close_notify never sent
-  #
-  # Mechanism (step by step):
-  # 1. TLS 1.3 handshake completes between lidi-file-send (client) and lidi-send (server).
-  # 2. lidi-send (OpenSSL 3.x, Mozilla Modern v5 = TLS 1.3 only) sends TWO NewSessionTicket
-  #    records post-handshake. These arrive in lidi-file-send's kernel TCP receive buffer.
-  # 3. lidi-file-send only writes to the TLS stream (header + data + footer + flush).
-  #    It never calls read() on the connection, so the NewSessionTicket records are never
-  #    consumed from its receive buffer.
-  # 4. send_file_aux() returns; the TcpStream wrapper is dropped. TcpStream has no Drop
-  #    impl, so openssl::ssl::SslStream is dropped without calling SSL_shutdown().
-  #    → No TLS close_notify is sent.
-  # 5. The Linux TCP stack detects unread data in lidi-file-send's receive buffer
-  #    (the two NewSessionTicket records) and sends TCP RST instead of FIN.
-  # 6. lidi-send receives the RST. Per RFC 793, all data in lidi-send's TCP receive
-  #    buffer (the file bytes) is immediately discarded.
-  # 7. lidi-send's client worker calls read() → ECONNRESET. It logs:
-  #    "client 0: error: I/O error: Connection reset by peer (os error 104)"
-  #    and sends an Abort block. No file data is ever processed.
-  #
-  # Proof: openssl s_client (which sends close_notify) → "disconnect, 5 bytes sent" ✓
-  #        lidi-file-send (no close_notify)             → "Connection reset by peer" ✗
-  #
-  # Fix (not yet applied): implement Drop for lidi_clients::tls::TcpStream to call
-  #   self.0.shutdown()
-  # This drains pending server records (NewSessionTicket) and closes the connection
-  # with a clean FIN instead of RST.
 
-  @wip
   Scenario: T-TLS01 Basic TLS file transfer (send side)
     Given lidi is started with TLS on the send side
     When send file test.bin via TLS connection of size 100KB
     Then lidi-file-receive file test.bin in 10 seconds
 
-  @wip
   Scenario: T-TLS02 Mutual TLS (mTLS) — client certificate required
     Given lidi is started with mutual TLS on the send side
     When send file test.bin via mutual TLS connection of size 100KB
     Then lidi-file-receive file test.bin in 10 seconds
 
-  @wip
   Scenario: T-TLS03 Mozilla Modern v5 preset explicit
     Given TLS send method is mozilla_modern_v5
     And lidi is started with TLS on the send side
     When send file test.bin via TLS connection of size 100KB
     Then lidi-file-receive file test.bin in 10 seconds
 
-  @wip
   Scenario: T-TLS04 Mozilla Intermediate v5 preset
     Given TLS send method is mozilla_intermediate_v5
     And lidi is started with TLS on the send side
     When send file test.bin via TLS connection of size 100KB
     Then lidi-file-receive file test.bin in 10 seconds
 
-  @wip
   Scenario: T-TLS05 Custom cipher suite (TLS 1.3 ciphers)
     Given TLS send cipher suite is TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256
     And lidi is started with TLS on the send side
     When send file test.bin via TLS connection of size 100KB
     Then lidi-file-receive file test.bin in 10 seconds
 
-  @wip
   Scenario: T-TLS06 TLS endpoint with flush=true option
     Given TLS send endpoint has option flush=true
     And lidi is started with TLS on the send side
     When send file test.bin via TLS connection of size 100KB
     Then lidi-file-receive file test.bin in 10 seconds
 
-  @wip
   Scenario: T-TLS07 TLS with hash enabled
     Given TLS send endpoint has option hash=true
     And lidi is started with TLS on the send side
@@ -91,7 +51,6 @@ Feature: TLS encryption between lidi-file-send / lidi-send and lidi-receive / li
     Then lidi-file-receive file test.bin in 10 seconds
     And the hash is logged for file test.bin
 
-  @wip
   Scenario: T-TLS08 TLS minimum version tls1_3 explicit
     Given TLS send minimum version is tls1_3
     And lidi is started with TLS on the send side

--- a/features/valgrind_mmsg.feature
+++ b/features/valgrind_mmsg.feature
@@ -50,8 +50,8 @@ Feature: Valgrind memcheck on unsafe UDP socket implementation (msg and mmsg)
     And UDP send mode is mmsg
     And UDP receive mode is native
     And lidi is started with max throughput of 10mbit
-    When lidi-file-send file valgrind_send_mmsg.bin of size 5MB
-    Then lidi-file-receive file valgrind_send_mmsg.bin in 60 seconds
+    When lidi-file-send file valgrind_send_mmsg.bin of size 1MB
+    Then lidi-file-receive file valgrind_send_mmsg.bin in 15 seconds
     And valgrind reports no memory errors on lidi-send
 
   # send=native, recv=mmsg — isolates the receive side
@@ -67,8 +67,8 @@ Feature: Valgrind memcheck on unsafe UDP socket implementation (msg and mmsg)
     And UDP send mode is native
     And UDP receive mode is mmsg
     And lidi is started with max throughput of 10mbit
-    When lidi-file-send file valgrind_recv_mmsg.bin of size 5MB
-    Then lidi-file-receive file valgrind_recv_mmsg.bin in 60 seconds
+    When lidi-file-send file valgrind_recv_mmsg.bin of size 1MB
+    Then lidi-file-receive file valgrind_recv_mmsg.bin in 15 seconds
     And valgrind reports no memory errors on lidi-receive
 
   # send=mmsg, recv=mmsg — full mmsg pipeline, both sides under valgrind
@@ -80,8 +80,8 @@ Feature: Valgrind memcheck on unsafe UDP socket implementation (msg and mmsg)
     And UDP send mode is mmsg
     And UDP receive mode is mmsg
     And lidi is started with max throughput of 10mbit
-    When lidi-file-send file valgrind_mmsg_full.bin of size 5MB
-    Then lidi-file-receive file valgrind_mmsg_full.bin in 60 seconds
+    When lidi-file-send file valgrind_mmsg_full.bin of size 1MB
+    Then lidi-file-receive file valgrind_mmsg_full.bin in 15 seconds
     And valgrind reports no memory errors on lidi-send
     And valgrind reports no memory errors on lidi-receive
 
@@ -95,8 +95,8 @@ Feature: Valgrind memcheck on unsafe UDP socket implementation (msg and mmsg)
     And UDP send mode is msg
     And UDP receive mode is native
     And lidi is started with max throughput of 10mbit
-    When lidi-file-send file valgrind_send_msg.bin of size 5MB
-    Then lidi-file-receive file valgrind_send_msg.bin in 60 seconds
+    When lidi-file-send file valgrind_send_msg.bin of size 1MB
+    Then lidi-file-receive file valgrind_send_msg.bin in 15 seconds
     And valgrind reports no memory errors on lidi-send
 
   # send=native, recv=msg — isolates the recvmsg(2) single-datagram path
@@ -110,16 +110,16 @@ Feature: Valgrind memcheck on unsafe UDP socket implementation (msg and mmsg)
     And UDP send mode is native
     And UDP receive mode is msg
     And lidi is started with max throughput of 10mbit
-    When lidi-file-send file valgrind_recv_msg.bin of size 5MB
-    Then lidi-file-receive file valgrind_recv_msg.bin in 60 seconds
+    When lidi-file-send file valgrind_recv_msg.bin of size 1MB
+    Then lidi-file-receive file valgrind_recv_msg.bin in 15 seconds
     And valgrind reports no memory errors on lidi-receive
 
   # send=mmsg, recv=mmsg, large transfer — exercises repeated reuse of the
   # pinned iovec/mmsghdr arrays across many consecutive RaptorQ blocks.
-  # At block=20000 B and MTU=1500 each block produces ~16 packets, so a
-  # 10 MB file generates ~600 blocks → ~600 sendmmsg() calls and a
-  # matching number of recvmmsg() calls, each reusing the same 1024-entry
-  # iovec and mmsghdr arrays.
+  # At default block=220 000 B and MTU=1500 each block produces ~150 packets;
+  # a 2 MB file generates ~9 blocks → ~9 sendmmsg() calls and a matching
+  # number of recvmmsg() calls, each reusing the same 1024-entry iovec and
+  # mmsghdr arrays.
   # Validates: no use-after-free or stale iov_base pointer across repeated
   # calls; correct re-initialisation of msg_len before each sendmmsg call.
   Scenario: Valgrind: no memory errors in mmsg across many blocks (TV6)
@@ -128,8 +128,8 @@ Feature: Valgrind memcheck on unsafe UDP socket implementation (msg and mmsg)
     And UDP send mode is mmsg
     And UDP receive mode is mmsg
     And lidi is started with max throughput of 10mbit
-    When lidi-file-send file valgrind_mmsg_large.bin of size 10MB
-    Then lidi-file-receive file valgrind_mmsg_large.bin in 600 seconds
+    When lidi-file-send file valgrind_mmsg_large.bin of size 2MB
+    Then lidi-file-receive file valgrind_mmsg_large.bin in 30 seconds
     And valgrind reports no memory errors on lidi-send
     And valgrind reports no memory errors on lidi-receive
 
@@ -145,9 +145,9 @@ Feature: Valgrind memcheck on unsafe UDP socket implementation (msg and mmsg)
     And UDP send mode is mmsg
     And UDP receive mode is mmsg
     And lidi is started with max throughput of 10mbit
-    When lidi-file-send file valgrind_mmsg_consec_a.bin of size 5MB
-    And lidi-file-receive file valgrind_mmsg_consec_a.bin in 30 seconds
-    And lidi-file-send file valgrind_mmsg_consec_b.bin of size 5MB
-    Then lidi-file-receive file valgrind_mmsg_consec_b.bin in 30 seconds
+    When lidi-file-send file valgrind_mmsg_consec_a.bin of size 1MB
+    And lidi-file-receive file valgrind_mmsg_consec_a.bin in 15 seconds
+    And lidi-file-send file valgrind_mmsg_consec_b.bin of size 1MB
+    Then lidi-file-receive file valgrind_mmsg_consec_b.bin in 15 seconds
     And valgrind reports no memory errors on lidi-send
     And valgrind reports no memory errors on lidi-receive

--- a/lidi-bindings/Cargo.toml
+++ b/lidi-bindings/Cargo.toml
@@ -14,6 +14,8 @@ path = "../lidi-clients"
 default-features = false
 
 [features]
-default = [ "hash", "inotify" ]
+default = [ "hash", "inotify", "tmp-file" ]
 hash = [ "lidi-clients/hash" ]
 inotify = [ "lidi-clients/inotify" ]
+tmp-file = [ "lidi-clients/tmp-file" ]
+

--- a/lidi-bindings/src/lib.rs
+++ b/lidi-bindings/src/lib.rs
@@ -32,6 +32,8 @@ pub unsafe extern "C" fn diode_new_config(
         hash: false,
         max_files: 0,
         overwrite: false,
+        #[cfg(feature = "tmp-file")]
+        use_tmp_file: false,
         ignore: None,
         recursive: false,
         watch: false,
@@ -108,6 +110,8 @@ pub unsafe extern "C" fn diode_receive_files(
         hash: false,
         max_files: 0,
         overwrite: false,
+        #[cfg(feature = "tmp-file")]
+        use_tmp_file: false,
         ignore: None,
         recursive: false,
         watch: false,

--- a/lidi-clients/Cargo.toml
+++ b/lidi-clients/Cargo.toml
@@ -58,6 +58,11 @@ version = "0"
 default-features = false
 features = [ "termcolor", "local-offset" ]
 
+[dependencies.tempfile]
+version = "3"
+optional = true
+default-features = false
+
 [dependencies.twox-hash]
 version = "2"
 optional = true
@@ -65,10 +70,11 @@ default-features = false
 features = [ "std", "xxhash3_128" ]
 
 [features]
-default = [ "hash", "inotify", "log4rs", "tcp", "tls", "unix" ]
+default = [ "hash", "inotify", "log4rs", "tcp", "tls", "tmp-file", "unix" ]
 hash = [ "dep:twox-hash" ]
 inotify = [ "dep:inotify" ]
 log4rs = [ "dep:log4rs" ]
 tcp = [ ]
 tls = [ "dep:openssl" ]
+tmp-file = [ "dep:tempfile" ]
 unix = [ ]

--- a/lidi-clients/src/bin/lidi-dir-send.rs
+++ b/lidi-clients/src/bin/lidi-dir-send.rs
@@ -104,6 +104,8 @@ fn main() {
         hash: args.hash,
         max_files: args.max_files,
         overwrite: false,
+        #[cfg(feature = "tmp-file")]
+        use_tmp_file: false,
         ignore: args.ignore,
         recursive: args.recursive,
         watch: args.watch,

--- a/lidi-clients/src/bin/lidi-file-receive.rs
+++ b/lidi-clients/src/bin/lidi-file-receive.rs
@@ -25,6 +25,18 @@ struct Listeners {
     from_unix: Option<path::PathBuf>,
 }
 
+#[derive(clap::Args)]
+struct WriteOptions {
+    #[clap(long, help = "Overwrite existing files")]
+    overwrite: bool,
+    #[cfg(feature = "tmp-file")]
+    #[clap(
+        long,
+        help = "Write to .tmp file and rename atomically (prevents partial files on crash)"
+    )]
+    use_tmp_file: bool,
+}
+
 #[derive(Parser)]
 #[clap(about = "Receive file(s) sent by lidi-file-send through lidi.")]
 struct Args {
@@ -56,8 +68,8 @@ struct Args {
         help = "Exits after receiving max_files files"
     )]
     max_files: usize,
-    #[clap(long, help = "Overwrite existing files")]
-    overwrite: bool,
+    #[clap(flatten)]
+    write_options: WriteOptions,
     #[clap(flatten)]
     tls: lidi_clients::Tls,
     #[clap(long, help = "Chroot in output directory before receiving files")]
@@ -97,7 +109,9 @@ fn main() {
         #[cfg(feature = "hash")]
         hash: args.hash,
         max_files: args.max_files,
-        overwrite: args.overwrite,
+        overwrite: args.write_options.overwrite,
+        #[cfg(feature = "tmp-file")]
+        use_tmp_file: args.write_options.use_tmp_file,
         ignore: None,
         recursive: false,
         watch: false,

--- a/lidi-clients/src/bin/lidi-file-send.rs
+++ b/lidi-clients/src/bin/lidi-file-send.rs
@@ -91,6 +91,8 @@ fn main() {
         hash: args.hash,
         max_files: 0,
         overwrite: false,
+        #[cfg(feature = "tmp-file")]
+        use_tmp_file: false,
         ignore: None,
         recursive: false,
         watch: false,

--- a/lidi-clients/src/file/mod.rs
+++ b/lidi-clients/src/file/mod.rs
@@ -16,6 +16,8 @@ pub struct Config<D> {
     pub hash: bool,
     pub max_files: usize,
     pub overwrite: bool,
+    #[cfg(feature = "tmp-file")]
+    pub use_tmp_file: bool,
     pub ignore: Option<regex::Regex>,
     pub recursive: bool,
     pub watch: bool,

--- a/lidi-clients/src/file/receive.rs
+++ b/lidi-clients/src/file/receive.rs
@@ -179,6 +179,32 @@ where
     log::debug!("setting mode to {}", header.mode);
     file.set_permissions(fs::Permissions::from_mode(header.mode))?;
 
+    match write_file_content(&mut diode, &mut file, &header, config) {
+        Ok(received) => Ok(received),
+        Err(e) => {
+            // The transfer was incomplete or invalid (e.g. the sending client was
+            // killed mid-transfer): remove the partially written file so it does
+            // not get mistaken for a successfully received one.
+            if let Err(remove_err) = fs::remove_file(&file_path) {
+                log::warn!(
+                    "failed to remove incomplete file {}: {remove_err}",
+                    file_path.display()
+                );
+            }
+            Err(e)
+        }
+    }
+}
+
+fn write_file_content<D>(
+    diode: &mut D,
+    file: &mut fs::File,
+    header: &file::protocol::Header,
+    config: &file::Config<crate::DiodeReceive>,
+) -> Result<usize, file::Error>
+where
+    D: Read + Write,
+{
     let mut buffer = vec![0; config.buffer_size];
     let mut cursor = 0;
     let mut remaining = usize::try_from(header.file_length)?;
@@ -221,7 +247,7 @@ where
 
                 #[cfg(feature = "hash")]
                 if let Some(hasher) = hasher.as_mut() {
-                    let footer = file::protocol::Footer::deserialize_from(&mut diode)?;
+                    let footer = file::protocol::Footer::deserialize_from(&mut *diode)?;
                     let hash = hasher.finalize();
                     log::debug!("expected hash = {}", footer.hash);
                     log::debug!("computed hash = {hash}");

--- a/lidi-clients/src/file/receive.rs
+++ b/lidi-clients/src/file/receive.rs
@@ -14,6 +14,21 @@ use std::{
     path, thread,
 };
 
+#[cfg(feature = "tmp-file")]
+fn cleanup_tmp_files(output_dir: &path::Path) {
+    if let Ok(entries) = fs::read_dir(output_dir) {
+        for entry in entries.flatten() {
+            let entry_path = entry.path();
+            if entry_path.extension().is_some_and(|ext| ext == "tmp") {
+                match fs::remove_file(&entry_path) {
+                    Ok(()) => log::info!("cleaned up orphaned tmp file: {}", entry_path.display()),
+                    Err(e) => log::warn!("failed to remove tmp file {}: {e}", entry_path.display()),
+                }
+            }
+        }
+    }
+}
+
 /// # Errors
 ///
 /// Will return `Err` if `output_dir` is not a directory.
@@ -25,6 +40,11 @@ pub fn receive_files(
         return Err(file::Error::Other(String::from(
             "output_directory is not a directory",
         )));
+    }
+
+    #[cfg(feature = "tmp-file")]
+    if config.use_tmp_file {
+        cleanup_tmp_files(output_dir);
     }
 
     thread::scope(|scope| -> Result<(), file::Error> {
@@ -169,6 +189,11 @@ where
         fs::create_dir_all(parent)?;
     }
 
+    #[cfg(feature = "tmp-file")]
+    if config.use_tmp_file {
+        return receive_file_via_tmp_file(&mut diode, &header, config, &file_path);
+    }
+
     let mut file = fs::OpenOptions::new()
         .read(false)
         .write(true)
@@ -194,6 +219,47 @@ where
             Err(e)
         }
     }
+}
+
+/// Writes the file content to a uniquely-named temporary file in the same
+/// directory as `file_path`, then atomically renames it into place. If
+/// writing fails, the temporary file is automatically removed on drop.
+#[cfg(feature = "tmp-file")]
+fn receive_file_via_tmp_file<D>(
+    diode: &mut D,
+    header: &file::protocol::Header,
+    config: &file::Config<crate::DiodeReceive>,
+    file_path: &path::Path,
+) -> Result<usize, file::Error>
+where
+    D: Read + Write,
+{
+    let dir = file_path.parent().unwrap_or_else(|| path::Path::new("."));
+    let file_name = file_path
+        .file_name()
+        .ok_or_else(|| file::Error::Other(format!("invalid file path {}", file_path.display())))?;
+
+    let mut tmp = tempfile::Builder::new()
+        .prefix(file_name)
+        .suffix(".tmp")
+        .tempfile_in(dir)?;
+
+    log::debug!("setting mode to {}", header.mode);
+    tmp.as_file()
+        .set_permissions(fs::Permissions::from_mode(header.mode))?;
+
+    let received = write_file_content(diode, tmp.as_file_mut(), header, config)?;
+
+    tmp.as_file().sync_all()?;
+    let tmp_path = tmp.path().to_path_buf();
+    tmp.persist(file_path).map_err(|e| e.error)?;
+    log::debug!(
+        "atomically persisted {} to {}",
+        tmp_path.display(),
+        file_path.display()
+    );
+
+    Ok(received)
 }
 
 fn write_file_content<D>(

--- a/lidi-clients/src/tls.rs
+++ b/lidi-clients/src/tls.rs
@@ -118,6 +118,25 @@ impl io::Write for TcpStream {
     }
 }
 
+impl Drop for TcpStream {
+    fn drop(&mut self) {
+        // Drain pending server-sent TLS records (e.g. TLS 1.3 NewSessionTicket)
+        // before closing. Without this, Linux sends TCP RST instead of FIN when
+        // the socket is closed with unread data in the receive buffer, which causes
+        // the peer's read() to fail with ECONNRESET and discard buffered data.
+        let _ = self.0.get_ref().set_nonblocking(true);
+        let mut buf = [0u8; 1024];
+        loop {
+            match io::Read::read(&mut self.0, &mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => continue,
+            }
+        }
+        let _ = self.0.get_ref().set_nonblocking(false);
+        let _ = self.0.shutdown();
+    }
+}
+
 impl os::fd::AsRawFd for TcpStream {
     fn as_raw_fd(&self) -> i32 {
         self.0.get_ref().as_raw_fd()

--- a/lidi-receive/src/bin/lidi-receive.rs
+++ b/lidi-receive/src/bin/lidi-receive.rs
@@ -106,6 +106,12 @@ fn main() {
         return;
     }
 
+    // Validate max_clients is greater than 0
+    if config.common.max_clients() == 0 {
+        eprintln!("configuration error: max_clients must be greater than 0 (got 0)");
+        std::process::exit(1);
+    }
+
     // Validate MTU minimum (1280 is IPv6 minimum)
     let mtu = config.common.mtu();
     if mtu < 1280 {

--- a/lidi-receive/src/client_reorder.rs
+++ b/lidi-receive/src/client_reorder.rs
@@ -54,6 +54,20 @@ where
         #[allow(clippy::cast_precision_loss)]
         gauge_queue.set(recvq.len() as f64);
 
+        let block_type = block.block_type()?;
+
+        // Abort bypasses sequence reordering: it is an out-of-band terminator
+        // that must reach client::start immediately regardless of what sequence
+        // number it carries.  Dispatch assigns seq=0 to sync-loss Aborts (it has
+        // no per-client sequence counter), so waiting for in-order delivery would
+        // stall the worker for the full abort_timeout before the TCP connection is
+        // finally closed and the partial file cleaned up.
+        if matches!(block_type, protocol::BlockType::Abort) {
+            log::warn!("client {client_id:x}: aborting transfer");
+            to_client.send(block)?;
+            break;
+        }
+
         let sequence_number = block.sequence_number();
 
         log::trace!("client {client_id:x}: receiving block with sequence number {sequence_number}");
@@ -81,27 +95,18 @@ where
 
         log::trace!("client {client_id:x}: payload {} bytes", payload.len());
 
-        let block_type = block.block_type()?;
-
         to_client.send(block)?;
 
-        if matches!(
-            block_type,
-            protocol::BlockType::Abort | protocol::BlockType::End
-        ) {
+        if matches!(block_type, protocol::BlockType::End) {
             #[cfg(feature = "hash")]
             if let Some(hasher) = hasher {
                 let hash = hasher.finalize();
                 log::info!("client {client_id:x}: hash is {hash:x}");
             }
 
-            if matches!(block_type, protocol::BlockType::Abort) {
-                log::warn!("client {client_id:x}: aborting transfer");
-            } else {
-                log::info!(
-                    "client {client_id:x}: finished transfer, {transmitted} bytes transmitted"
-                );
-            }
+            log::info!(
+                "client {client_id:x}: finished transfer, {transmitted} bytes transmitted"
+            );
 
             break;
         }

--- a/lidi-send/src/bin/lidi-send.rs
+++ b/lidi-send/src/bin/lidi-send.rs
@@ -240,6 +240,12 @@ fn main() {
         return;
     }
 
+    // Validate max_clients is greater than 0
+    if config.common.max_clients() == 0 {
+        eprintln!("configuration error: max_clients must be greater than 0 (got 0)");
+        std::process::exit(1);
+    }
+
     // Validate MTU minimum (1280 is IPv6 minimum)
     let mtu = config.common.mtu();
     if mtu < 1280 {


### PR DESCRIPTION
Add more tests and reduce global test duration (no more sleep, more reactive)

there are 2 fixes:
* fix: bypass sequence reordering for Abort blocks in client_reorder
* fix(tls): drain receive buffer before shutdown in TcpStream::drop