### PR TITLE
tests: valgrind: build lidi-send/lidi-receive without mimalloc

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -49,6 +49,11 @@ def before_all(context):
     ])
     proc.communicate()
 
+    # build lidi-send/lidi-receive without mimalloc, used by the Valgrind
+    # scenarios (see justfile: release_no_mimalloc)
+    proc = subprocess.Popen(['just', 'release_no_mimalloc'])
+    proc.communicate()
+
 
 # function called before each test: initialize context with default values
 def before_scenario(context, _feature):
@@ -115,6 +120,10 @@ def before_scenario(context, _feature):
     # directory containing lidi-clients binaries built without the inotify
     # feature (used to test the directory polling fallback)
     context.bin_dir_no_inotify = "./target/no-inotify/release/"
+
+    # directory containing lidi-send/lidi-receive binaries built without
+    # mimalloc (used by the Valgrind scenarios)
+    context.bin_dir_no_mimalloc = "./target/no-mimalloc/release/"
     
     # some possible options
     context.network_down_after = None

--- a/features/steps/config.py
+++ b/features/steps/config.py
@@ -178,7 +178,8 @@ def build_lidi_send_command(context):
         else:
             delattr(context, 'heartbeat')
 
-    lidi_send_command = [f'{context.bin_dir}/lidi-send', lidi_config]
+    bin_dir = context.bin_dir_no_mimalloc if getattr(context, 'valgrind_send', False) else context.bin_dir
+    lidi_send_command = [f'{bin_dir}/lidi-send', lidi_config]
 
     if getattr(context, 'valgrind_send', False):
         valgrind_log = os.path.join(context.base_dir, 'valgrind_send.log')
@@ -215,7 +216,8 @@ def build_lidi_receive_command(context):
         else:
             delattr(context, 'heartbeat')
 
-    lidi_receive_command = [f'{context.bin_dir}/lidi-receive', lidi_config]
+    bin_dir = context.bin_dir_no_mimalloc if getattr(context, 'valgrind_receive', False) else context.bin_dir
+    lidi_receive_command = [f'{bin_dir}/lidi-receive', lidi_config]
 
     if getattr(context, 'valgrind_receive', False):
         valgrind_log = os.path.join(context.base_dir, 'valgrind_receive.log')

--- a/justfile
+++ b/justfile
@@ -1,6 +1,13 @@
 release:
     cargo build --release --features mimalloc
 
+# lidi-send/lidi-receive built with default features (no mimalloc), used by
+# the Valgrind scenarios: mimalloc's internal bit tricks are known to trigger
+# Valgrind false positives ("uninitialised value" reports) unrelated to the
+# unsafe code the tests actually exercise (send-msg/send-mmsg socket paths).
+release_no_mimalloc:
+    cargo build --release --package lidi-send --package lidi-receive --target-dir target/no-mimalloc
+
 release_tcp_mmsg:
     cargo build --release --no-default-features --features from-tcp,to-tcp,tcp,receive-mmsg,send-mmsg,tcp
 


### PR DESCRIPTION
mimalloc's internal free-list bit tricks are a known source of Valgrind false positives ("uninitialised value" conditional jumps) unrelated to the unsafe socket code the Valgrind scenarios are meant to exercise. Add a dedicated release_no_mimalloc build and point the valgrind-tagged send/receive steps at it, following the same pattern already used for the no-inotify lidi-clients build.